### PR TITLE
feat: update aweXpect to v0.33.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.24.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="0.20.0"/>
+		<PackageVersion Include="aweXpect" Version="0.33.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="0.31.0"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>
 	</ItemGroup>

--- a/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
@@ -18,7 +18,7 @@ public static partial class FileInfoExtensions
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<IFileInfo, IThat<IFileInfo>>(
-			source.ThatIs().ExpectationBuilder.AddConstraint(it
+			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new HasContentValueConstraint(
 					it, "have", expected, options)),
 			source,
@@ -46,6 +46,6 @@ public static partial class FileInfoExtensions
 		}
 
 		public override string ToString()
-			=> $"{verb} Content {options.GetExpectation(expected, false)}{options}";
+			=> $"{verb} Content {options.GetExpectation(expected, ExpectationGrammars.None)}{options}";
 	}
 }

--- a/Source/aweXpect.Testably/FileSystemExtensions.HasDirectory.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.HasDirectory.cs
@@ -13,7 +13,7 @@ public static partial class FileSystemExtensions
 	public static DirectoryResult<TFileSystem> HasDirectory<TFileSystem>(
 		this IThat<TFileSystem> subject, string path)
 		where TFileSystem : IFileSystem
-		=> new(subject.ThatIs().ExpectationBuilder.AddConstraint(it
+		=> new(subject.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new HasDirectoryConstraint<TFileSystem>(it, path)),
 			subject,
 			path);
@@ -42,6 +42,6 @@ public static partial class FileSystemExtensions
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"have directory '{path}'";
+			=> $"has directory '{path}'";
 	}
 }

--- a/Source/aweXpect.Testably/FileSystemExtensions.HasFile.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.HasFile.cs
@@ -13,7 +13,7 @@ public static partial class FileSystemExtensions
 	public static FileResult<TFileSystem> HasFile<TFileSystem>(
 		this IThat<TFileSystem> subject, string path)
 		where TFileSystem : IFileSystem
-		=> new(subject.ThatIs().ExpectationBuilder.AddConstraint(it
+		=> new(subject.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new HasFileConstraint<TFileSystem>(it, path)),
 			subject,
 			path);
@@ -42,6 +42,6 @@ public static partial class FileSystemExtensions
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"have file '{path}'";
+			=> $"has file '{path}'";
 	}
 }

--- a/Source/aweXpect.Testably/Results/DirectoryResult.cs
+++ b/Source/aweXpect.Testably/Results/DirectoryResult.cs
@@ -29,9 +29,9 @@ public class DirectoryResult<TFileSystem>(
 			.ForMember(
 				MemberAccessor<TFileSystem, IEnumerable<IFileInfo>>.FromFunc(
 					f => f.Directory.EnumerateFiles(path).Select(p => f.FileInfo.New(p)), "files "),
-				(property, expectation) => $" which {property}should {expectation}")
+				(member, expectation) => expectation.Append(" whose ").Append(member))
 			.AddExpectations(e
-				=> expectations(new ThatSubject<IEnumerable<IFileInfo>>(e)));
+				=> expectations(new ThatSubject<IEnumerable<IFileInfo>>(e)), ExpectationGrammars.Nested);
 		return this;
 	}
 
@@ -45,9 +45,9 @@ public class DirectoryResult<TFileSystem>(
 			.ForMember(
 				MemberAccessor<TFileSystem, IEnumerable<IDirectoryInfo>>.FromFunc(
 					f => f.Directory.EnumerateDirectories(path).Select(p => f.DirectoryInfo.New(p)), "subdirectories "),
-				(property, expectation) => $" which {property}should {expectation}")
+				(member, expectation) => expectation.Append(" whose ").Append(member))
 			.AddExpectations(e
-				=> expectations(new ThatSubject<IEnumerable<IDirectoryInfo>>(e)));
+				=> expectations(new ThatSubject<IEnumerable<IDirectoryInfo>>(e)), ExpectationGrammars.Nested);
 		return this;
 	}
 }

--- a/Source/aweXpect.Testably/Results/FileResult.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.cs
@@ -27,7 +27,7 @@ public class FileResult<TFileSystem>(
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.And(" ").AddConstraint(it
+			_expectationBuilder.And(" ").AddConstraint((it, grammar)
 				=> new HasContentConstraint(it, path, options, expected)),
 			this, options);
 	}
@@ -35,14 +35,15 @@ public class FileResult<TFileSystem>(
 	/// <summary>
 	///     Verifies that the string content of the file satisfies the <paramref name="expectations" />.
 	/// </summary>
-	public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> WhichContent(
+	public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> WhoseContent(
 		Action<IThat<string?>> expectations)
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.ForMember(
+			_expectationBuilder
+				.ForMember(
 					MemberAccessor<TFileSystem, string>.FromFunc(f => f.File.ReadAllText(path), "content "),
-					(member, expectation) => $" which {member}should {expectation}")
+					(member, expectation) => expectation.Append(" whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<string?>(e))),
 			this, options);
 	}
@@ -59,7 +60,7 @@ public class FileResult<TFileSystem>(
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.And(" ").AddConstraint(it
+			_expectationBuilder.And(" ").AddConstraint((it, grammar)
 				=> new HasTimeConstraint(it, path,
 					f => f.CreationTime, tolerance,
 					expected, "creation time")),
@@ -78,7 +79,7 @@ public class FileResult<TFileSystem>(
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.And(" ").AddConstraint(it
+			_expectationBuilder.And(" ").AddConstraint((it, grammar)
 				=> new HasTimeConstraint(it, path,
 					f => f.LastAccessTime, tolerance,
 					expected, "last access time")),
@@ -97,7 +98,7 @@ public class FileResult<TFileSystem>(
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.And(" ").AddConstraint(it
+			_expectationBuilder.And(" ").AddConstraint((it, grammar)
 				=> new HasTimeConstraint(it, path,
 					f => f.LastWriteTime, tolerance,
 					expected, "last write time")),

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -27,7 +27,7 @@ namespace aweXpect.Testably.Results
         where TFileSystem : System.IO.Abstractions.IFileSystem
     {
         public FileResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TFileSystem> subject, string path) { }
-        public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhichContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhoseContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(string expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithCreationTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastAccessTime(System.DateTime expected) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -27,7 +27,7 @@ namespace aweXpect.Testably.Results
         where TFileSystem : System.IO.Abstractions.IFileSystem
     {
         public FileResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TFileSystem> subject, string path) { }
-        public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhichContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhoseContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(string expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithCreationTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastAccessTime(System.DateTime expected) { }

--- a/Tests/aweXpect.Testably.Tests/HasDirectory.WithDirectoriesTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasDirectory.WithDirectoriesTests.cs
@@ -17,12 +17,12 @@ public partial class HasDirectory
 				.WithSubdirectory("directory2"));
 
 			async Task Act()
-				=> await That(sut).HasDirectory(path).WithDirectories(f => f.Has().Exactly(3).Items());
+				=> await That(sut).HasDirectory(path).WithDirectories(f => f.HasCount().EqualTo(3));
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have directory '{path}' which subdirectories should have exactly 3 items,
+				              Expected that sut
+				              has directory '{path}' whose subdirectories has exactly 3 items,
 				              but found only 2
 				              """);
 		}
@@ -37,7 +37,7 @@ public partial class HasDirectory
 				.WithSubdirectory("directory2"));
 
 			async Task Act()
-				=> await That(sut).HasDirectory(path).WithDirectories(f => f.Has().Exactly(2).Items());
+				=> await That(sut).HasDirectory(path).WithDirectories(f => f.HasCount().EqualTo(2));
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Testably.Tests/HasDirectory.WithFilesTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasDirectory.WithFilesTests.cs
@@ -21,8 +21,8 @@ public partial class HasDirectory
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have directory '{path}' which files should be empty,
+				              Expected that sut
+				              has directory '{path}' whose files are empty,
 				              but files was [
 				                foo{Path.DirectorySeparatorChar}bar.txt
 				              ]
@@ -52,12 +52,12 @@ public partial class HasDirectory
 
 			async Task Act()
 				=> await That(sut).HasDirectory(path)
-					.WithFiles(f => f.All().Are(x => x.HasContent("SOME-CONTENT")));
+					.WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME-CONTENT")));
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have directory '{path}' which files should have all items have Content equal to "SOME-CONTENT",
+				              Expected that sut
+				              has directory '{path}' whose files have Content equal to "SOME-CONTENT" for all items,
 				              but not all were
 				              """);
 		}
@@ -72,7 +72,7 @@ public partial class HasDirectory
 
 			async Task Act()
 				=> await That(sut).HasDirectory(path)
-					.WithFiles(f => f.All().Are(x => x.HasContent("SOME-CONTENT").IgnoringCase()));
+					.WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME-CONTENT").IgnoringCase()));
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Testably.Tests/HasDirectoryTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasDirectoryTests.cs
@@ -16,8 +16,8 @@ public class HasDirectoryTests
 
 		await That(Act).ThrowsException()
 			.WithMessage($"""
-			              Expected sut to
-			              have directory '{path}',
+			              Expected that sut
+			              has directory '{path}',
 			              but it did not exist
 			              """);
 	}
@@ -35,8 +35,8 @@ public class HasDirectoryTests
 
 		await That(Act).ThrowsException()
 			.WithMessage($"""
-			              Expected sut to
-			              have directory '{path}',
+			              Expected that sut
+			              has directory '{path}',
 			              but it was a file
 			              """);
 	}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WhichContentTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WhichContentTests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Testably.Tests;
 
 public partial class HasFile
 {
-	public class WhichContentTests
+	public class WhoseContentTests
 	{
 		[Fact]
 		public async Task WhenContentIsDifferent_ShouldFail()
@@ -16,12 +16,12 @@ public partial class HasFile
 			sut.File.WriteAllText(path, "baz");
 
 			async Task Act()
-				=> await That(sut).HasFile(path).WhichContent(c => c.IsEmpty());
+				=> await That(sut).HasFile(path).WhoseContent(c => c.IsEmpty());
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' which content should be empty,
+				              Expected that sut
+				              has file '{path}' whose content is empty,
 				              but content was "baz"
 				              """);
 		}
@@ -35,7 +35,7 @@ public partial class HasFile
 			sut.File.WriteAllText(path, "");
 
 			async Task Act()
-				=> await That(sut).HasFile(path).WhichContent(c => c.IsEmpty());
+				=> await That(sut).HasFile(path).WhoseContent(c => c.IsEmpty());
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContentTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContentTests.cs
@@ -20,8 +20,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with content "bar",
+				              Expected that sut
+				              has file '{path}' with content "bar",
 				              but it was "baz" which differs at index 2:
 				                   ↓ (actual)
 				                "baz"

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithCreationTimeTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithCreationTimeTests.cs
@@ -23,8 +23,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with creation time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with creation time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}
@@ -44,8 +44,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with creation time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with creation time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithLastAccessTimeTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithLastAccessTimeTests.cs
@@ -23,8 +23,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with last access time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with last access time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}
@@ -44,8 +44,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with last access time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with last access time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithLastWriteTimeTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithLastWriteTimeTests.cs
@@ -23,8 +23,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with last write time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with last write time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}
@@ -44,8 +44,8 @@ public partial class HasFile
 
 			await That(Act).ThrowsException()
 				.WithMessage($"""
-				              Expected sut to
-				              have file '{path}' with last write time equal to {Formatter.Format(expectedTime)},
+				              Expected that sut
+				              has file '{path}' with last write time equal to {Formatter.Format(expectedTime)},
 				              but it was {Formatter.Format(actualTime)}
 				              """);
 		}

--- a/Tests/aweXpect.Testably.Tests/HasFileTests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFileTests.cs
@@ -16,8 +16,8 @@ public class HasFileTests
 
 		await That(Act).ThrowsException()
 			.WithMessage($"""
-			              Expected sut to
-			              have file '{path}',
+			              Expected that sut
+			              has file '{path}',
 			              but it did not exist
 			              """);
 	}
@@ -34,8 +34,8 @@ public class HasFileTests
 
 		await That(Act).ThrowsException()
 			.WithMessage($"""
-			              Expected sut to
-			              have file '{path}',
+			              Expected that sut
+			              has file '{path}',
 			              but it was a directory
 			              """);
 	}


### PR DESCRIPTION
Update aweXpect and adapt API to conform to breaking changes in the meantime:
- Rename `WhichContent` to `WhoseContent`