### PR TITLE
docs: fix link for code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Testably)](https://www.nuget.org/packages/aweXpect.Testably)
 [![Build](https://github.com/aweXpect/aweXpect.Testably/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Testably/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Testably&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Testably)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Testably&metric=coverage)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Testably)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Testably&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Testably)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Testably%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Testably/main)
 
 Expectations for the file and time system


### PR DESCRIPTION
Change link to overall section instead of new code.