### PR TITLE
feat: add binary content check

### DIFF
--- a/Source/aweXpect.Testably/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect.Testably/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,33 @@
+﻿#if !NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	///     Indicates that a parameter captures the expression passed for another parameter as a string.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	[ExcludeFromCodeCoverage]
+	internal sealed class CallerArgumentExpressionAttribute : Attribute
+	{
+		/// <summary>
+		///     Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute" /> class.
+		/// </summary>
+		/// <param name="parameterName">The name of the parameter whose expression should be captured as a string.</param>
+		public CallerArgumentExpressionAttribute(string parameterName)
+		{
+			ParameterName = parameterName;
+		}
+
+		/// <summary>
+		///     Gets the name of the parameter whose expression should be captured as a string.
+		/// </summary>
+		public string ParameterName { get; }
+	}
+}
+
+#endif

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -21,6 +21,17 @@ public partial class FileResult<TFileSystem>
 		string path)
 	{
 		/// <summary>
+		///     …is equal to the <paramref name="expected" /> binary.
+		/// </summary>
+		public AndOrResult<TFileSystem, FileResult<TFileSystem>> EqualTo(
+			byte[] expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+			=> new(
+				expectationBuilder.And(" ").AddConstraint((it, grammar)
+					=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
+				subject);
+
+		/// <summary>
 		///     …is equal to the <paramref name="expected" /> string.
 		/// </summary>
 		public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> EqualTo(
@@ -34,6 +45,18 @@ public partial class FileResult<TFileSystem>
 		}
 
 		/// <summary>
+		///     …differs from the <paramref name="unexpected" /> binary.
+		/// </summary>
+		public AndOrResult<TFileSystem, FileResult<TFileSystem>> DifferentFrom(
+			byte[] unexpected,
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
+			=> new(
+				expectationBuilder.And(" ").AddConstraint((it, grammar)
+					=> new HasBinaryContentDifferentFromConstraint(it, path, unexpected, doNotPopulateThisValue)),
+				subject);
+
+		/// <summary>
 		///     …differs from the <paramref name="unexpected" /> string.
 		/// </summary>
 		public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> DifferentFrom(
@@ -45,29 +68,6 @@ public partial class FileResult<TFileSystem>
 					=> new HasStringContentDifferentFromConstraint(it, path, options, unexpected)),
 				subject, options);
 		}
-
-		/// <summary>
-		///     …is equal to the <paramref name="expected" /> binary.
-		/// </summary>
-		public AndOrResult<TFileSystem, FileResult<TFileSystem>> EqualTo(
-			byte[] expected,
-			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-			=> new(
-				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
-				subject);
-
-		/// <summary>
-		///     …differs from the <paramref name="unexpected" /> binary.
-		/// </summary>
-		public AndOrResult<TFileSystem, FileResult<TFileSystem>> DifferentFrom(
-			byte[] unexpected,
-			[CallerArgumentExpression("unexpected")]
-			string doNotPopulateThisValue = "")
-			=> new(
-				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasBinaryContentDifferentFromConstraint(it, path, unexpected, doNotPopulateThisValue)),
-				subject);
 	}
 
 	private readonly struct HasBinaryContentConstraint(

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Core;
+﻿using System.Linq;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -43,6 +45,79 @@ public partial class FileResult<TFileSystem>
 					=> new HasStringContentDifferentFromConstraint(it, path, options, unexpected)),
 				subject, options);
 		}
+
+		/// <summary>
+		///     …is equal to the <paramref name="expected" /> binary.
+		/// </summary>
+		public AndOrResult<TFileSystem, FileResult<TFileSystem>> EqualTo(
+			byte[] expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+			=> new(
+				expectationBuilder.And(" ").AddConstraint((it, grammar)
+					=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
+				subject);
+
+		/// <summary>
+		///     …differs from the <paramref name="unexpected" /> binary.
+		/// </summary>
+		public AndOrResult<TFileSystem, FileResult<TFileSystem>> DifferentFrom(
+			byte[] unexpected,
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
+			=> new(
+				expectationBuilder.And(" ").AddConstraint((it, grammar)
+					=> new HasBinaryContentDifferentFromConstraint(it, path, unexpected, doNotPopulateThisValue)),
+				subject);
+	}
+
+	private readonly struct HasBinaryContentConstraint(
+		string it,
+		string path,
+		byte[] expected,
+		string expectedExpression)
+		: IValueConstraint<TFileSystem>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(TFileSystem actual)
+		{
+			byte[] content = actual.File.ReadAllBytes(path);
+			if (content.SequenceEqual(expected))
+			{
+				return new ConstraintResult.Success<TFileSystem>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
+				$"{it} differed");
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"with content equal to {expectedExpression}";
+	}
+
+	private readonly struct HasBinaryContentDifferentFromConstraint(
+		string it,
+		string path,
+		byte[] expected,
+		string expectedExpression)
+		: IValueConstraint<TFileSystem>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(TFileSystem actual)
+		{
+			byte[] content = actual.File.ReadAllBytes(path);
+			if (!content.SequenceEqual(expected))
+			{
+				return new ConstraintResult.Success<TFileSystem>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
+				$"{it} did match");
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"with content different from {expectedExpression}";
 	}
 
 	private readonly struct HasStringContentConstraint(

--- a/Source/aweXpect.Testably/Results/FileResult.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO.Abstractions;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;
@@ -37,6 +38,17 @@ public partial class FileResult<TFileSystem>(
 				=> new HasStringContentConstraint(it, grammar, path, options, expected)),
 			this, options);
 	}
+
+	/// <summary>
+	///     Verifies that the file has the <paramref name="expected" /> binary content.
+	/// </summary>
+	public AndOrResult<TFileSystem, FileResult<TFileSystem>> WithContent(
+		byte[] expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(
+			_expectationBuilder.And(" ").AddConstraint((it, grammar)
+				=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
+			this);
 
 	/// <summary>
 	///     Verifies that the string content of the file satisfies the <paramref name="expectations" />.

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -30,6 +30,7 @@ namespace aweXpect.Testably.Results
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhoseContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public aweXpect.Testably.Results.FileResult<TFileSystem>.Content WithContent() { }
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(string expected) { }
+        public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithCreationTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastAccessTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastWriteTime(System.DateTime expected) { }
@@ -37,7 +38,9 @@ namespace aweXpect.Testably.Results
         {
             public Content(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Testably.Results.FileResult<TFileSystem> subject, string path) { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> DifferentFrom(string unexpected) { }
+            public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> DifferentFrom(byte[] unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(string expected) { }
+            public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -30,6 +30,7 @@ namespace aweXpect.Testably.Results
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WhoseContent(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public aweXpect.Testably.Results.FileResult<TFileSystem>.Content WithContent() { }
         public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(string expected) { }
+        public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithContent(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithCreationTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastAccessTime(System.DateTime expected) { }
         public aweXpect.Results.TimeToleranceResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> WithLastWriteTime(System.DateTime expected) { }
@@ -37,7 +38,9 @@ namespace aweXpect.Testably.Results
         {
             public Content(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Testably.Results.FileResult<TFileSystem> subject, string path) { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> DifferentFrom(string unexpected) { }
+            public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> DifferentFrom(byte[] unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(string expected) { }
+            public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         }
     }
 }


### PR DESCRIPTION
Add overloads for `byte[]` in `EqualTo` and `DifferentFrom` that compares the binary content of the file.