### PR TITLE
feat: add `SameAs`/`NotSameAs` for file content

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,6 +1,6 @@
 ﻿# [aweXpect.Testably](https://github.com/aweXpect/aweXpect.Testably) [![Nuget](https://img.shields.io/nuget/v/aweXpect.Testably)](https://www.nuget.org/packages/aweXpect.Testably)
 
-Expectations for the file and time system from Testably.Abstractions.
+Expectations for the file and time system from [Testably.Abstractions](https://github.com/Testably/Testably.Abstractions).
 
 
 ## File system
@@ -9,7 +9,9 @@ You can verify that a specific file or directory exists in the file system:
 
 ```csharp
 IFileSystem fileSystem = new MockFileSystem();
-//...
+fileSystem.Directory.CreateDirectory("my/path");
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
 await That(fileSystem).HasDirectory("my/path");
 await That(fileSystem).HasFile("my-file.txt");
 ```
@@ -19,16 +21,34 @@ await That(fileSystem).HasFile("my-file.txt");
 For files, you can verify the file content:
 
 ```csharp
-await That(fileSystem).HasFile("my-file.txt").WithContent("file-content").IgnoringCase();
-await That(fileSystem).HasFile("my-file.txt").WithContent().DifferentTo("some unexpected content");
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(fileSystem).HasFile("my-file.txt").WithContent("some content").IgnoringCase();
+await That(fileSystem).HasFile("my-file.txt").WithContent().NotEqualTo("some unexpected content");
+```
+
+You can also verify the file content with regard to another file:
+
+```csharp
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+fileSystem.File.WriteAllText("my-other-file.txt", "SOME CONTENT");
+fileSystem.File.WriteAllText("my-third-file.txt", "some other content");
+
+await That(fileSystem).HasFile("my-file.txt").WithContent().SameAs("my-other-file.txt").IgnoringCase();
+await That(fileSystem).HasFile("my-file.txt").WithContent().NotSameAs("my-third-file.txt");
 ```
 
 For files, you can verify the creation time, last access time and last write time:
 
 ```csharp
-await That(sut).HasFile(path).WithCreationTime(expectedTime).Within(1.Second());
-await That(sut).HasFile(path).WithLastAccessTime(expectedTime).Within(1.Second());
-await That(sut).HasFile(path).LastWriteTime(expectedTime).Within(1.Second());
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(sut).HasFile(path).WithCreationTime(DateTime.Now).Within(1.Second());
+await That(sut).HasFile(path).WithLastAccessTime(DateTime.Now).Within(1.Second());
+await That(sut).HasFile(path).LastWriteTime(DateTime.Now).Within(1.Second());
 ```
 
 ### Directory
@@ -36,11 +56,19 @@ await That(sut).HasFile(path).LastWriteTime(expectedTime).Within(1.Second());
 For directories, you can verify that they contain subdirectories:
 
 ```csharp
-await That(sut).HasDirectory(path).WithDirectories(f => f.HasCount().EqualTo(2));
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.Directory.CreateDirectory("foo/bar1");
+fileSystem.Directory.CreateDirectory("foo/bar2/baz");
+
+await That(fileSystem).HasDirectory("foo").WithDirectories(f => f.HasCount().EqualTo(2));
 ```
 
 For directories, you can verify that they contain files:
 
 ```csharp
-await That(sut).HasDirectory(path).WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME-CONTENT")));
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.Directory.CreateDirectory("foo/bar");
+fileSystem.File.WriteAllText("foo/bar/my-file.txt", "some content");
+
+await That(fileSystem).HasDirectory("foo/bar").WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME CONTENT").IgnoringCase()));
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ You can verify that a specific file or directory exists in the file system:
 
 ```csharp
 IFileSystem fileSystem = new MockFileSystem();
-//...
+fileSystem.Directory.CreateDirectory("my/path");
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
 await That(fileSystem).HasDirectory("my/path");
 await That(fileSystem).HasFile("my-file.txt");
 ```
@@ -25,15 +27,34 @@ await That(fileSystem).HasFile("my-file.txt");
 For files, you can verify the file content:
 
 ```csharp
-await That(fileSystem).HasFile("my-file.txt").WithContent("file-content").IgnoringCase();
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(fileSystem).HasFile("my-file.txt").WithContent("some content").IgnoringCase();
+await That(fileSystem).HasFile("my-file.txt").WithContent().NotEqualTo("some unexpected content");
+```
+
+You can also verify the file content with regard to another file:
+
+```csharp
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+fileSystem.File.WriteAllText("my-other-file.txt", "SOME CONTENT");
+fileSystem.File.WriteAllText("my-third-file.txt", "some other content");
+
+await That(fileSystem).HasFile("my-file.txt").WithContent().SameAs("my-other-file.txt").IgnoringCase();
+await That(fileSystem).HasFile("my-file.txt").WithContent().NotSameAs("my-third-file.txt");
 ```
 
 For files, you can verify the creation time, last access time and last write time:
 
 ```csharp
-await That(sut).HasFile(path).WithCreationTime(expectedTime).Within(1.Second());
-await That(sut).HasFile(path).WithLastAccessTime(expectedTime).Within(1.Second());
-await That(sut).HasFile(path).LastWriteTime(expectedTime).Within(1.Second());
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(sut).HasFile(path).WithCreationTime(DateTime.Now).Within(1.Second());
+await That(sut).HasFile(path).WithLastAccessTime(DateTime.Now).Within(1.Second());
+await That(sut).HasFile(path).LastWriteTime(DateTime.Now).Within(1.Second());
 ```
 
 ### Directory
@@ -41,11 +62,19 @@ await That(sut).HasFile(path).LastWriteTime(expectedTime).Within(1.Second());
 For directories, you can verify that they contain subdirectories:
 
 ```csharp
-await That(sut).HasDirectory(path).WithDirectories(f => f.HasCount().EqualTo(2));
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.Directory.CreateDirectory("foo/bar1");
+fileSystem.Directory.CreateDirectory("foo/bar2/baz");
+
+await That(fileSystem).HasDirectory("foo").WithDirectories(f => f.HasCount().EqualTo(2));
 ```
 
 For directories, you can verify that they contain files:
 
 ```csharp
-await That(sut).HasDirectory(path).WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME-CONTENT")));
+IFileSystem fileSystem = new MockFileSystem();
+fileSystem.Directory.CreateDirectory("foo/bar");
+fileSystem.File.WriteAllText("foo/bar/my-file.txt", "some content");
+
+await That(fileSystem).HasDirectory("foo/bar").WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME CONTENT").IgnoringCase()));
 ```

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -210,10 +210,6 @@ public partial class FileResult<TFileSystem>
 
 		private static string ToString(string fullPath)
 			=> $"with the same content as '{fullPath}'";
-
-		/// <inheritdoc />
-		public override string ToString()
-			=> ToString(expectedPath);
 	}
 
 	private readonly struct HasContentNotSameAsConstraint(
@@ -251,10 +247,6 @@ public partial class FileResult<TFileSystem>
 
 		private static string ToString(string fullPath)
 			=> $"with not the same content as '{fullPath}'";
-
-		/// <inheritdoc />
-		public override string ToString()
-			=> ToString(expectedPath);
 	}
 
 	private readonly struct HasStringContentNotEqualToConstraint(

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -28,7 +28,7 @@ public partial class FileResult<TFileSystem>
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 			=> new(
 				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
+					=> new HasBinaryContentEqualToConstraint(it, path, expected, doNotPopulateThisValue)),
 				subject);
 
 		/// <summary>
@@ -39,8 +39,8 @@ public partial class FileResult<TFileSystem>
 		{
 			StringEqualityOptions options = new();
 			return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
-				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasStringContentConstraint(it, grammar, path, options, expected)),
+				expectationBuilder.And(" ").AddConstraint((expectationBuilder, it, grammar)
+					=> new HasStringContentEqualToConstraint(expectationBuilder, it, grammar, path, options, expected)),
 				subject, options);
 		}
 
@@ -53,7 +53,7 @@ public partial class FileResult<TFileSystem>
 			string doNotPopulateThisValue = "")
 			=> new(
 				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasBinaryContentDifferentFromConstraint(it, path, unexpected, doNotPopulateThisValue)),
+					=> new HasBinaryContentNotEqualToConstraint(it, path, unexpected, doNotPopulateThisValue)),
 				subject);
 
 		/// <summary>
@@ -64,13 +64,39 @@ public partial class FileResult<TFileSystem>
 		{
 			StringEqualityOptions options = new();
 			return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
-				expectationBuilder.And(" ").AddConstraint((it, grammar)
-					=> new HasStringContentDifferentFromConstraint(it, path, options, unexpected)),
+				expectationBuilder.And(" ").AddConstraint((expectationBuilder, it, grammar)
+					=> new HasStringContentNotEqualToConstraint(expectationBuilder, it, path, options, unexpected)),
+				subject, options);
+		}
+
+		/// <summary>
+		///     …has the same content as the file on the <paramref name="filePath" />.
+		/// </summary>
+		public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> SameAs(
+			string filePath)
+		{
+			StringEqualityOptions options = new();
+			return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
+				expectationBuilder.And(" ").AddConstraint((expectationBuilder, it, grammar)
+					=> new HasContentSameAsConstraint(expectationBuilder, it, path, options, filePath)),
+				subject, options);
+		}
+
+		/// <summary>
+		///     …does not have the same content as the file on the <paramref name="filePath" />.
+		/// </summary>
+		public StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>> NotSameAs(
+			string filePath)
+		{
+			StringEqualityOptions options = new();
+			return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
+				expectationBuilder.And(" ").AddConstraint((expectationBuilder, it, grammar)
+					=> new HasContentNotSameAsConstraint(expectationBuilder, it, path, options, filePath)),
 				subject, options);
 		}
 	}
 
-	private readonly struct HasBinaryContentConstraint(
+	private readonly struct HasBinaryContentEqualToConstraint(
 		string it,
 		string path,
 		byte[] expected,
@@ -95,7 +121,7 @@ public partial class FileResult<TFileSystem>
 			=> $"with content equal to {expectedExpression}";
 	}
 
-	private readonly struct HasBinaryContentDifferentFromConstraint(
+	private readonly struct HasBinaryContentNotEqualToConstraint(
 		string it,
 		string path,
 		byte[] expected,
@@ -120,7 +146,8 @@ public partial class FileResult<TFileSystem>
 			=> $"with content different from {expectedExpression}";
 	}
 
-	private readonly struct HasStringContentConstraint(
+	private readonly struct HasStringContentEqualToConstraint(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammar,
 		string path,
@@ -137,6 +164,8 @@ public partial class FileResult<TFileSystem>
 				return new ConstraintResult.Success<TFileSystem>(actual, ToString());
 			}
 
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("File content", content)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
 				options.GetExtendedFailure(it, content, expected));
 		}
@@ -146,7 +175,90 @@ public partial class FileResult<TFileSystem>
 			=> $"with content {options.GetExpectation(expected, grammar)}";
 	}
 
-	private readonly struct HasStringContentDifferentFromConstraint(
+	private readonly struct HasContentSameAsConstraint(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		string path,
+		StringEqualityOptions options,
+		string expectedPath)
+		: IValueConstraint<TFileSystem>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(TFileSystem actual)
+		{
+			string actualContent = actual.File.ReadAllText(path);
+			string fullPath = actual.Path.GetFullPath(expectedPath);
+			if (!actual.File.Exists(expectedPath))
+			{
+				expectationBuilder.UpdateContexts(contexts => contexts
+					.Add(new ResultContext("File content", actualContent)));
+				return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
+					$"{it} did not contain any file at '{fullPath}'");
+			}
+
+			string expectedContent = actual.File.ReadAllText(expectedPath);
+			if (options.AreConsideredEqual(actualContent, expectedContent))
+			{
+				return new ConstraintResult.Success<TFileSystem>(actual, ToString(fullPath));
+			}
+
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("File content", actualContent)));
+			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
+				options.GetExtendedFailure(it, actualContent, expectedContent));
+		}
+
+		private static string ToString(string fullPath)
+			=> $"with the same content as '{fullPath}'";
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> ToString(expectedPath);
+	}
+
+	private readonly struct HasContentNotSameAsConstraint(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		string path,
+		StringEqualityOptions options,
+		string expectedPath)
+		: IValueConstraint<TFileSystem>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(TFileSystem actual)
+		{
+			string actualContent = actual.File.ReadAllText(path);
+			string fullPath = actual.Path.GetFullPath(expectedPath);
+			if (!actual.File.Exists(expectedPath))
+			{
+				expectationBuilder.UpdateContexts(contexts => contexts
+					.Add(new ResultContext("File content", actualContent)));
+				return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
+					$"{it} did not contain any file at '{fullPath}'");
+			}
+
+			string expectedContent = actual.File.ReadAllText(expectedPath);
+			if (!options.AreConsideredEqual(actualContent, expectedContent))
+			{
+				return new ConstraintResult.Success<TFileSystem>(actual, ToString(fullPath));
+			}
+
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("File content", actualContent)));
+			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
+				$"{it} did match");
+		}
+
+		private static string ToString(string fullPath)
+			=> $"with not the same content as '{fullPath}'";
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> ToString(expectedPath);
+	}
+
+	private readonly struct HasStringContentNotEqualToConstraint(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		string path,
 		StringEqualityOptions options,
@@ -162,7 +274,8 @@ public partial class FileResult<TFileSystem>
 				return new ConstraintResult.Success<TFileSystem>(actual, ToString());
 			}
 
-
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("File content", content)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
 				$"{it} did match");
 		}

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -12,6 +12,8 @@ namespace aweXpect.Testably.Results;
 /// </summary>
 public partial class FileResult<TFileSystem>
 {
+	private const string FileContentContext = "File content";
+
 	/// <summary>
 	///     The result for additional verifications on a file content.
 	/// </summary>
@@ -165,7 +167,7 @@ public partial class FileResult<TFileSystem>
 			}
 
 			expectationBuilder.UpdateContexts(contexts => contexts
-				.Add(new ResultContext("File content", content)));
+				.Add(new ResultContext(FileContentContext, content)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
 				options.GetExtendedFailure(it, content, expected));
 		}
@@ -191,7 +193,7 @@ public partial class FileResult<TFileSystem>
 			if (!actual.File.Exists(expectedPath))
 			{
 				expectationBuilder.UpdateContexts(contexts => contexts
-					.Add(new ResultContext("File content", actualContent)));
+					.Add(new ResultContext(FileContentContext, actualContent)));
 				return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
 					$"{it} did not contain any file at '{fullPath}'");
 			}
@@ -203,7 +205,7 @@ public partial class FileResult<TFileSystem>
 			}
 
 			expectationBuilder.UpdateContexts(contexts => contexts
-				.Add(new ResultContext("File content", actualContent)));
+				.Add(new ResultContext(FileContentContext, actualContent)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
 				options.GetExtendedFailure(it, actualContent, expectedContent));
 		}
@@ -228,7 +230,7 @@ public partial class FileResult<TFileSystem>
 			if (!actual.File.Exists(expectedPath))
 			{
 				expectationBuilder.UpdateContexts(contexts => contexts
-					.Add(new ResultContext("File content", actualContent)));
+					.Add(new ResultContext(FileContentContext, actualContent)));
 				return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
 					$"{it} did not contain any file at '{fullPath}'");
 			}
@@ -240,7 +242,7 @@ public partial class FileResult<TFileSystem>
 			}
 
 			expectationBuilder.UpdateContexts(contexts => contexts
-				.Add(new ResultContext("File content", actualContent)));
+				.Add(new ResultContext(FileContentContext, actualContent)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(fullPath),
 				$"{it} did match");
 		}
@@ -267,7 +269,7 @@ public partial class FileResult<TFileSystem>
 			}
 
 			expectationBuilder.UpdateContexts(contexts => contexts
-				.Add(new ResultContext("File content", content)));
+				.Add(new ResultContext(FileContentContext, content)));
 			return new ConstraintResult.Failure<TFileSystem>(actual, ToString(),
 				$"{it} did match");
 		}

--- a/Source/aweXpect.Testably/Results/FileResult.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.cs
@@ -34,8 +34,8 @@ public partial class FileResult<TFileSystem>(
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<TFileSystem, FileResult<TFileSystem>>(
-			_expectationBuilder.And(" ").AddConstraint((it, grammar)
-				=> new HasStringContentConstraint(it, grammar, path, options, expected)),
+			_expectationBuilder.And(" ").AddConstraint((expectationBuilder, it, grammar)
+				=> new HasStringContentEqualToConstraint(expectationBuilder, it, grammar, path, options, expected)),
 			this, options);
 	}
 
@@ -47,7 +47,7 @@ public partial class FileResult<TFileSystem>(
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(
 			_expectationBuilder.And(" ").AddConstraint((it, grammar)
-				=> new HasBinaryContentConstraint(it, path, expected, doNotPopulateThisValue)),
+				=> new HasBinaryContentEqualToConstraint(it, path, expected, doNotPopulateThisValue)),
 			this);
 
 	/// <summary>

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotEqualTo(string unexpected) { }
             public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotEqualTo(byte[] unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+            public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotSameAs(string filePath) { }
+            public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> SameAs(string filePath) { }
         }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> EqualTo(byte[] expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotEqualTo(string unexpected) { }
             public aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotEqualTo(byte[] unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+            public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> NotSameAs(string filePath) { }
+            public aweXpect.Results.StringEqualityTypeResult<TFileSystem, aweXpect.Testably.Results.FileResult<TFileSystem>> SameAs(string filePath) { }
         }
     }
 }

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContent.NotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContent.NotEqualTo.Tests.cs
@@ -82,6 +82,9 @@ public partial class HasFile
 						              Expected that sut
 						              has file '{path}' with content different from "bar",
 						              but it did match
+						              
+						              File content:
+						              bar
 						              """);
 				}
 			}
@@ -118,6 +121,9 @@ public partial class HasFile
 						              Expected that sut
 						              has file '{path}' with content different from "ba?",
 						              but it did match
+						              
+						              File content:
+						              bar
 						              """);
 				}
 			}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContent.NotSameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContent.NotSameAs.Tests.cs
@@ -1,0 +1,102 @@
+﻿using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public partial class HasFile
+{
+	public sealed partial class WithContent
+	{
+		public class NotSameAs
+		{
+			public sealed class StringTests
+			{
+				[Fact]
+				public async Task WhenContentIsDifferent_ShouldSucceed()
+				{
+					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					// ReSharper disable once MethodHasAsyncOverload
+					sut.File.WriteAllText(path, "baz");
+					sut.File.WriteAllText(expectedPath, "bar");
+
+					async Task Act()
+						=> await That(sut).HasFile(path).WithContent().NotSameAs(expectedPath);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenContentMatches_ShouldFail()
+				{
+					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string content = "bar";
+					string expectedPath = "bar.txt";
+					string fullExpectedPath = sut.Path.GetFullPath(expectedPath);
+					// ReSharper disable once MethodHasAsyncOverload
+					sut.File.WriteAllText(path, content);
+					sut.File.WriteAllText(expectedPath, content);
+
+					async Task Act()
+						=> await That(sut).HasFile(path).WithContent().NotSameAs(expectedPath);
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that sut
+						              has file '{path}' with not the same content as '{fullExpectedPath}',
+						              but it did match
+
+						              File content:
+						              bar
+						              """);
+				}
+			}
+
+			public sealed class AsWildcardTests
+			{
+				[Fact]
+				public async Task WhenContentIsDifferent_ShouldSucceed()
+				{
+					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					// ReSharper disable once MethodHasAsyncOverload
+					sut.File.WriteAllText(path, "baz");
+					sut.File.WriteAllText(expectedPath, "b?");
+
+					async Task Act()
+						=> await That(sut).HasFile(path).WithContent().NotSameAs(expectedPath).AsWildcard();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenContentMatches_ShouldFail()
+				{
+					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					string fullExpectedPath = sut.Path.GetFullPath(expectedPath);
+					// ReSharper disable once MethodHasAsyncOverload
+					sut.File.WriteAllText(path, "bar");
+					sut.File.WriteAllText(expectedPath, "ba?");
+
+					async Task Act()
+						=> await That(sut).HasFile(path).WithContent().NotSameAs(expectedPath).AsWildcard();
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that sut
+						              has file '{path}' with not the same content as '{fullExpectedPath}',
+						              but it did match
+
+						              File content:
+						              bar
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContent.SameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContent.SameAs.Tests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO.Abstractions;
-using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
@@ -8,70 +7,34 @@ public partial class HasFile
 {
 	public sealed partial class WithContent
 	{
-		public class EqualTo
+		public class SameAs
 		{
-			public sealed class BinaryTests
-			{
-				[Fact]
-				public async Task WhenContentIsDifferent_ShouldFail()
-				{
-					byte[] content = Encoding.UTF8.GetBytes("baz");
-					byte[] expected = Encoding.UTF8.GetBytes("bar");
-					string path = "foo.txt";
-					IFileSystem sut = new MockFileSystem();
-					// ReSharper disable once MethodHasAsyncOverload
-					sut.File.WriteAllBytes(path, content);
-
-					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo(expected);
-
-					await That(Act).ThrowsException()
-						.WithMessage($"""
-						              Expected that sut
-						              has file '{path}' with content equal to expected,
-						              but it differed
-						              """);
-				}
-
-				[Fact]
-				public async Task WhenContentMatches_ShouldSucceed()
-				{
-					byte[] content = Encoding.UTF8.GetBytes("baz");
-					string path = "foo.txt";
-					IFileSystem sut = new MockFileSystem();
-					// ReSharper disable once MethodHasAsyncOverload
-					sut.File.WriteAllBytes(path, content);
-
-					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo(content);
-
-					await That(Act).DoesNotThrow();
-				}
-			}
-
 			public sealed class StringTests
 			{
 				[Fact]
 				public async Task WhenContentIsDifferent_ShouldFail()
 				{
-					string path = "foo.txt";
 					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					string fullExpectedPath = sut.Path.GetFullPath(expectedPath);
 					// ReSharper disable once MethodHasAsyncOverload
 					sut.File.WriteAllText(path, "baz");
+					sut.File.WriteAllText(expectedPath, "bar");
 
 					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo("bar");
+						=> await That(sut).HasFile(path).WithContent().SameAs(expectedPath);
 
 					await That(Act).ThrowsException()
 						.WithMessage($"""
 						              Expected that sut
-						              has file '{path}' with content equal to "bar",
+						              has file '{path}' with the same content as '{fullExpectedPath}',
 						              but it was "baz" which differs at index 2:
 						                   ↓ (actual)
 						                "baz"
 						                "bar"
 						                   ↑ (expected)
-						              
+
 						              File content:
 						              baz
 						              """);
@@ -80,14 +43,16 @@ public partial class HasFile
 				[Fact]
 				public async Task WhenContentMatches_ShouldSucceed()
 				{
-					string path = "foo.txt";
-					string content = "bar";
 					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					string content = "bar";
 					// ReSharper disable once MethodHasAsyncOverload
 					sut.File.WriteAllText(path, content);
+					sut.File.WriteAllText(expectedPath, content);
 
 					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo(content);
+						=> await That(sut).HasFile(path).WithContent().SameAs(expectedPath);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -98,24 +63,27 @@ public partial class HasFile
 				[Fact]
 				public async Task WhenContentIsDifferent_ShouldFail()
 				{
-					string path = "foo.txt";
 					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
+					string fullExpectedPath = sut.Path.GetFullPath(expectedPath);
 					// ReSharper disable once MethodHasAsyncOverload
 					sut.File.WriteAllText(path, "baz");
+					sut.File.WriteAllText(expectedPath, "b?");
 
 					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo("b?").AsWildcard();
+						=> await That(sut).HasFile(path).WithContent().SameAs(expectedPath).AsWildcard();
 
 					await That(Act).ThrowsException()
 						.WithMessage($"""
 						              Expected that sut
-						              has file '{path}' with content matching "b?",
+						              has file '{path}' with the same content as '{fullExpectedPath}',
 						              but it did not match:
 						                ↓ (actual)
 						                "baz"
 						                "b?"
 						                ↑ (wildcard pattern)
-						              
+
 						              File content:
 						              baz
 						              """);
@@ -124,13 +92,15 @@ public partial class HasFile
 				[Fact]
 				public async Task WhenContentMatches_ShouldSucceed()
 				{
-					string path = "foo.txt";
 					IFileSystem sut = new MockFileSystem();
+					string path = "foo.txt";
+					string expectedPath = "bar.txt";
 					// ReSharper disable once MethodHasAsyncOverload
 					sut.File.WriteAllText(path, "bar");
+					sut.File.WriteAllText(expectedPath, "ba?");
 
 					async Task Act()
-						=> await That(sut).HasFile(path).WithContent().EqualTo("ba?").AsWildcard();
+						=> await That(sut).HasFile(path).WithContent().SameAs(expectedPath).AsWildcard();
 
 					await That(Act).DoesNotThrow();
 				}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContent.Tests.cs
@@ -29,6 +29,9 @@ public partial class HasFile
 					                "baz"
 					                "bar"
 					                   ↑ (expected)
+					              
+					              File content:
+					              baz
 					              """);
 			}
 
@@ -70,6 +73,9 @@ public partial class HasFile
 					                "baz"
 					                "b?"
 					                ↑ (wildcard pattern)
+					              
+					              File content:
+					              baz
 					              """);
 			}
 


### PR DESCRIPTION
You can now also verify the file content with regard to another file:

```csharp
IFileSystem fileSystem = new MockFileSystem();
fileSystem.File.WriteAllText("my-file.txt", "some content");
fileSystem.File.WriteAllText("my-other-file.txt", "SOME CONTENT");
fileSystem.File.WriteAllText("my-third-file.txt", "some other content");

await That(fileSystem).HasFile("my-file.txt").WithContent().SameAs("my-other-file.txt").IgnoringCase();
await That(fileSystem).HasFile("my-file.txt").WithContent().NotSameAs("my-third-file.txt");
```

---
- *Fixes #8*