### PR TITLE
refactor: add missing tests for `IFileInfo` `HasContent` expectation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.0.0-pre.3"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.0.0-pre.3"/>
+		<PackageVersion Include="aweXpect" Version="2.0.0-pre.4"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.0.0-pre.4"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>
 	</ItemGroup>

--- a/Tests/aweXpect.Testably.Tests/FileInfo.HasContentTests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.HasContentTests.cs
@@ -1,0 +1,62 @@
+﻿using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public class FileInfo
+{
+	public class HasContent
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenContentDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "bar2");
+				IFileInfo fileInfo = fileSystem.FileInfo.New("foo.txt");
+
+				async Task Act() => await That(fileInfo).HasContent("bar");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that fileInfo
+					             has Content equal to "bar",
+					             but it was "bar2" with a length of 4 which is longer than the expected length of 3 and has superfluous:
+					               "2"
+
+					             File-Content:
+					             bar2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenContentMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "bar");
+				IFileInfo fileInfo = fileSystem.FileInfo.New("foo.txt");
+
+				async Task Act() => await That(fileInfo).HasContent("bar");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFileDoesNotExist_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				IFileInfo fileInfo = fileSystem.FileInfo.New("foo.txt");
+
+				async Task Act() => await That(fileInfo).HasContent("bar");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that fileInfo
+					             has Content equal to "bar",
+					             but it did not exist
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/HasFile.WithContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/HasFile.WithContent.Tests.cs
@@ -29,7 +29,7 @@ public partial class HasFile
 					                "baz"
 					                "bar"
 					                   ↑ (expected)
-					              
+
 					              File content:
 					              baz
 					              """);
@@ -73,7 +73,7 @@ public partial class HasFile
 					                "baz"
 					                "b?"
 					                ↑ (wildcard pattern)
-					              
+
 					              File content:
 					              baz
 					              """);


### PR DESCRIPTION
Update aweXpect to v2.0.0-pre.4 due to a detected bugfix.