### PR TITLE
docs: notify Testably.Site when documentation changes

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,23 @@
+name: Notify Docs Site
+
+on:
+    push:
+        branches: [ main ]
+        paths:
+            - 'Docs/pages/**'
+            - 'README.md'
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        if: github.ref == 'refs/heads/main'
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Adds a workflow that fires the extension-documentation-updated-event repository dispatch at Testably/Testably.Site whenever Docs/pages/** or README.md changes on main. README.md is included because aweXpect's docs aggregator inlines it into 00-index.md via a {README} placeholder, so README changes affect the rendered site.

Requires a SITE_DISPATCH_TOKEN secret with repo write on Testably/ Testably.Site (recommended: configure once at the Testably org level).