### PR TITLE
chore: move SonarCloud project to Testably organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Testably) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Testably) with a quality gate that requires contributors to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect.Testably) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Testably) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -16,8 +16,8 @@ partial class Build
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect.Testably")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect.Testably")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Testably)](https://www.nuget.org/packages/aweXpect.Testably)
 [![Build](https://github.com/aweXpect/aweXpect.Testably/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Testably/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Testably&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Testably)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Testably&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Testably)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Testably&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Testably)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Testably&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Testably)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Testably%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Testably/main)
 
 Expectations for the file and time system


### PR DESCRIPTION
Updates the sonar organization to testably and renames the project key to Testably_aweXpect.Testably to match the new SonarCloud organization. README badges and CONTRIBUTING link are updated accordingly.