### PR TITLE
chore: Bump aweXpect.Core to 2.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.27.1"/>
+		<PackageVersion Include="aweXpect" Version="2.31.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.27.1"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.25.1"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>
 	</ItemGroup>

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -40,7 +40,6 @@ partial class Build
 
 			DotNetToolInstall(_ => _
 				.SetPackageName("dotnet-stryker")
-				.SetVersion("4.7.0")
 				.SetToolInstallationPath(toolPath));
 
 			Dictionary<Project, Project[]> projects = new()

--- a/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
@@ -74,7 +74,9 @@ public static partial class FileInfoExtensions
 #if NET8_0_OR_GREATER
 			_fileContent = await reader.ReadToEndAsync(cancellationToken);
 #else
+			cancellationToken.ThrowIfCancellationRequested();
 			_fileContent = await reader.ReadToEndAsync();
+			cancellationToken.ThrowIfCancellationRequested();
 #endif
 			Outcome = await options.AreConsideredEqual(_fileContent, expected) ? Outcome.Success : Outcome.Failure;
 			expectationBuilder.UpdateContexts(contexts => contexts

--- a/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasContent.cs
@@ -71,7 +71,11 @@ public static partial class FileInfoExtensions
 			}
 
 			using StreamReader reader = actual.OpenText();
+#if NET8_0_OR_GREATER
+			_fileContent = await reader.ReadToEndAsync(cancellationToken);
+#else
 			_fileContent = await reader.ReadToEndAsync();
+#endif
 			Outcome = await options.AreConsideredEqual(_fileContent, expected) ? Outcome.Success : Outcome.Failure;
 			expectationBuilder.UpdateContexts(contexts => contexts
 				.Add(new ResultContext.Fixed(Constants.FileContentContext, _fileContent)));


### PR DESCRIPTION
Updates the dependency on `aweXpect.Core` and adjusts file-content reading to respect cancellation when running on newer .NET targets, aligning `HasContent` constraints with the async-cancellation expectations in the library.

**Changes:**
- Bump `aweXpect.Core` package version to `2.29.0`.
- Forward `CancellationToken` to `StreamReader.ReadToEndAsync(CancellationToken)` for `net8.0+` builds.