### PR TITLE
chore: upload mutation test results to Stryker dashboard on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
         name: "Mutation tests"
         runs-on: windows-latest
         env:
-            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
             DOTNET_NOLOGO: true
         steps:
             -   uses: actions/checkout@v6
@@ -86,7 +85,38 @@ jobs:
                 uses: microsoft/setup-msbuild@v3
             -   name: Run mutation tests
                 run: ./build.ps1 MutationTests
-    
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v7
+                with:
+                    name: MutationTests
+                    path: |
+                        ./Artifacts/*
+
+    mutation-tests-dashboard:
+        name: "Mutation tests Dashboard"
+        needs: [ mutation-tests ]
+        runs-on: ubuntu-latest
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+            DOTNET_NOLOGO: true
+        steps:
+            -   uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v5
+                with:
+                    dotnet-version: |
+                        8.0.x
+                        9.0.x
+                        10.0.x
+            -   name: Upload to mutation dashboard
+                run: ./build.sh MutationTestDashboard
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.run_id }}
+
     benchmarks:
         name: "Benchmarks"
         runs-on: ubuntu-latest
@@ -162,7 +192,7 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, mutation-tests, benchmarks, static-code-analysis ]
+        needs: [ publish-test-results, mutation-tests-dashboard, benchmarks, static-code-analysis ]
         env:
             DOTNET_NOLOGO: true
         steps:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve how mutation test results are handled and uploaded. The main changes involve splitting the mutation testing and dashboard upload into separate jobs, ensuring artifacts are preserved, and updating job dependencies to reflect this new structure.

**Mutation testing workflow improvements:**

* Removed the `STRYKER_DASHBOARD_API_KEY` environment variable from the main `mutation-tests` job, reducing unnecessary secret exposure.
* Added an artifact upload step to the `mutation-tests` job to ensure mutation test results are saved for later use.

**Dashboard integration and workflow structure:**

* Introduced a new `mutation-tests-dashboard` job that depends on the completion of `mutation-tests`. This job uploads results to the mutation dashboard, using the appropriate secrets and environment variables.
* Updated the `pack` job to depend on `mutation-tests-dashboard` instead of `mutation-tests`, ensuring that packaging only occurs after dashboard upload is complete.