### PR TITLE
feat: add notification trigger assertions and ChangeDescription subjects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.32.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
-		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
-		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>
+		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.2.0"/>
+		<PackageVersion Include="Testably.Abstractions.Testing" Version="6.4.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/README.md
+++ b/README.md
@@ -105,3 +105,69 @@ same assertions light up in both places:
 await That(fileSystem).HasFile("my-file.txt").Which.HasLength(12).And.HasContent("some content");
 await That(fileSystem).HasDirectory("logs").Which.IsEmpty();
 ```
+
+### Notifications
+
+A `MockFileSystem` raises notifications when files or directories change. You
+can verify that a piece of code triggers (or does not trigger) a notification:
+
+```csharp
+MockFileSystem fileSystem = new();
+
+await That(fileSystem).TriggeredNotification(_ =>
+{
+    fileSystem.File.WriteAllText("my-file.txt", "some content");
+    return Task.CompletedTask;
+});
+
+await That(fileSystem).DidNotTriggerNotification(_ =>
+{
+    bool _ = fileSystem.Directory.Exists("/");
+    return Task.CompletedTask;
+}).Within(TimeSpan.FromMilliseconds(100));
+```
+
+`TriggeredNotification` accepts a `Quantifier` (`AtLeast`, `AtMost`, `Exactly`,
+`Between`, `Never`, `Once`) so you can assert how often the notification fires,
+and `.Matching(predicate)` narrows the assertion to specific changes:
+
+```csharp
+await That(fileSystem).TriggeredNotification(_ =>
+{
+    fileSystem.File.WriteAllText("a.txt", "x");
+    fileSystem.File.WriteAllText("b.txt", "y");
+    return Task.CompletedTask;
+}).Exactly(2.Times())
+  .Matching(c => c.ChangeType == WatcherChangeTypes.Created);
+```
+
+Both `TriggeredNotification` and `DidNotTriggerNotification` honour a
+`.Within(timeout)` (default 30 s) and expose `.Which` for further assertions on
+the list of captured `ChangeDescription`s:
+
+```csharp
+await That(fileSystem).TriggeredNotification(_ =>
+{
+    fileSystem.File.WriteAllText("a.txt", "x");
+    return Task.CompletedTask;
+}).Which.HasCount().EqualTo(1);
+```
+
+### `ChangeDescription` as a subject
+
+Individual `ChangeDescription` instances can be asserted directly. The
+`HasChangeType`, `HasFileSystemType` and `HasNotifyFilters` assertions use flag
+containment (so a `LastWrite | FileName` change satisfies
+`HasNotifyFilters(NotifyFilters.LastWrite)`); the empty / `default` value is
+rejected with an `ArgumentException` to avoid silent passes.
+
+```csharp
+await That(change).HasChangeType(WatcherChangeTypes.Created);
+await That(change).DoesNotHaveChangeType(WatcherChangeTypes.Deleted);
+
+await That(change).HasFileSystemType(FileSystemTypes.File);
+await That(change).HasNotifyFilters(NotifyFilters.LastWrite);
+
+await That(change).HasName("my-file.txt").And.HasPath("/abs/my-file.txt");
+await That(renamedChange).HasOldName("old.txt").And.HasOldPath("/abs/old.txt");
+```

--- a/README.md
+++ b/README.md
@@ -108,23 +108,33 @@ await That(fileSystem).HasDirectory("logs").Which.IsEmpty();
 
 ### Notifications
 
-A `MockFileSystem` raises notifications when files or directories change. You
-can verify that a piece of code triggers (or does not trigger) a notification:
+A `MockFileSystem` raises notifications when files or directories change. Run
+the code under test, then assert against the notifications it produced:
 
 ```csharp
 MockFileSystem fileSystem = new();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
 
-await That(fileSystem).TriggeredNotification(_ =>
-{
-    fileSystem.File.WriteAllText("my-file.txt", "some content");
-    return Task.CompletedTask;
-});
+await That(fileSystem).TriggeredNotification();
+await That(fileSystem).TriggeredNotification(c => c.Name == "my-file.txt");
+```
 
-await That(fileSystem).DidNotTriggerNotification(_ =>
-{
-    bool _ = fileSystem.Directory.Exists("/");
-    return Task.CompletedTask;
-}).Within(TimeSpan.FromMilliseconds(100));
+`.Within(timeout)` (default 30 s) lets the assertion wait for asynchronous
+notifications — if a matching notification already fired the assertion
+completes synchronously, otherwise it waits up to the timeout for a late
+arrival:
+
+```csharp
+_ = Task.Run(() => fileSystem.File.WriteAllText("foo.txt", "x"));
+await That(fileSystem).TriggeredNotification().Within(100.Milliseconds());
+```
+
+`DidNotTriggerNotification` mirrors the same shapes and short-circuits as soon
+as a matching notification is observed:
+
+```csharp
+await That(fileSystem).DidNotTriggerNotification().Within(100.Milliseconds());
+await That(fileSystem).DidNotTriggerNotification(c => c.Name == "secret.txt");
 ```
 
 `TriggeredNotification` accepts a `Quantifier` (`AtLeast`, `AtMost`, `Exactly`,
@@ -132,26 +142,27 @@ await That(fileSystem).DidNotTriggerNotification(_ =>
 and `.Matching(predicate)` narrows the assertion to specific changes:
 
 ```csharp
-await That(fileSystem).TriggeredNotification(_ =>
-{
-    fileSystem.File.WriteAllText("a.txt", "x");
-    fileSystem.File.WriteAllText("b.txt", "y");
-    return Task.CompletedTask;
-}).Exactly(2.Times())
-  .Matching(c => c.ChangeType == WatcherChangeTypes.Created);
+fileSystem.File.WriteAllText("a.txt", "x");
+fileSystem.File.WriteAllText("b.txt", "y");
+
+await That(fileSystem).TriggeredNotification()
+    .Matching(c => c.ChangeType == WatcherChangeTypes.Created)
+    .Exactly(2.Times());
 ```
 
-Both `TriggeredNotification` and `DidNotTriggerNotification` honour a
-`.Within(timeout)` (default 30 s) and expose `.Which` for further assertions on
-the list of captured `ChangeDescription`s:
+Both `TriggeredNotification` and `DidNotTriggerNotification` expose `.Which`
+for further assertions on the list of captured `ChangeDescription`s:
 
 ```csharp
-await That(fileSystem).TriggeredNotification(_ =>
-{
-    fileSystem.File.WriteAllText("a.txt", "x");
-    return Task.CompletedTask;
-}).Which.HasCount().EqualTo(1);
+fileSystem.File.WriteAllText("a.txt", "x");
+
+await That(fileSystem).TriggeredNotification().Which.HasCount().EqualTo(1);
 ```
+
+> Replay of historical notifications relies on the `MockFileSystem` notification
+> history. Disable it via
+> `new MockFileSystem(o => o.WithoutNotificationHistory())` only if you don't
+> use these assertions — they throw against a history-disabled file system.
 
 ### `ChangeDescription` as a subject
 

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="WatcherChangeTypes" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="WatcherChangeTypes" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasChangeType(
+		this IThat<ChangeDescription> source,
+		WatcherChangeTypes expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="WatcherChangeTypes" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveChangeType(
+		this IThat<ChangeDescription> source,
+		WatcherChangeTypes unexpected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, unexpected).Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -19,10 +20,18 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasChangeType(
 		this IThat<ChangeDescription> source,
 		WatcherChangeTypes expected)
-		=> new(
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected change type must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, expected)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
@@ -31,8 +40,16 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveChangeType(
 		this IThat<ChangeDescription> source,
 		WatcherChangeTypes unexpected)
-		=> new(
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected change type must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, unexpected).Invert()),
 			source);
+	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
@@ -1,0 +1,38 @@
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="FileSystemTypes" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="FileSystemTypes" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasFileSystemType(
+		this IThat<ChangeDescription> source,
+		FileSystemTypes expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="FileSystemTypes" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveFileSystemType(
+		this IThat<ChangeDescription> source,
+		FileSystemTypes unexpected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, unexpected).Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
@@ -1,3 +1,4 @@
+using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Results;
@@ -19,10 +20,18 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasFileSystemType(
 		this IThat<ChangeDescription> source,
 		FileSystemTypes expected)
-		=> new(
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected file system type must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, expected)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
@@ -31,8 +40,16 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveFileSystemType(
 		this IThat<ChangeDescription> source,
 		FileSystemTypes unexpected)
-		=> new(
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected file system type must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, unexpected).Invert()),
 			source);
+	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
@@ -1,0 +1,26 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasName(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.Name, options, expected, "name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="NotifyFilters" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="NotifyFilters" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasNotifyFilters(
+		this IThat<ChangeDescription> source,
+		NotifyFilters expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="NotifyFilters" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveNotifyFilters(
+		this IThat<ChangeDescription> source,
+		NotifyFilters unexpected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, unexpected).Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -19,10 +20,18 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasNotifyFilters(
 		this IThat<ChangeDescription> source,
 		NotifyFilters expected)
-		=> new(
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected notify filters must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, expected)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
@@ -31,8 +40,16 @@ public static partial class ChangeDescriptionExtensions
 	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveNotifyFilters(
 		this IThat<ChangeDescription> source,
 		NotifyFilters unexpected)
-		=> new(
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected notify filters must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, unexpected).Invert()),
 			source);
+	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
@@ -1,0 +1,29 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> old name.
+	/// </summary>
+	/// <remarks>
+	///     The old name is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldName(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.OldName, options, expected, "old name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
@@ -1,0 +1,29 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> old path.
+	/// </summary>
+	/// <remarks>
+	///     The old path is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldPath(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.OldPath, options, expected, "old path")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
@@ -1,0 +1,26 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> path.
+	/// </summary>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasPath(
+		this IThat<ChangeDescription> source,
+		string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.Path, options, expected, "path")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.cs
@@ -1,0 +1,10 @@
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="ChangeDescription" />.
+/// </summary>
+public static partial class ChangeDescriptionExtensions
+{
+}

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -76,7 +76,8 @@ public static partial class FileSystemExtensions
 		return new DidNotTriggerNotificationResult(
 			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.TriggeredNotificationConstraint(
-					it, grammars, triggerAction, filter, quantifier, options, captured).Invert()),
+					it, grammars, triggerAction, filter, quantifier, options, captured,
+					exitOnFirstMatch: true).Invert()),
 			subject,
 			captured,
 			filter,

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Testably.Helpers;
+using aweXpect.Testably.Results;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class FileSystemExtensions
+{
+	/// <summary>
+	///     Verifies that executing the <paramref name="triggerAction" /> caused the
+	///     <see cref="MockFileSystem.Notify" /> handler to fire.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes to <see cref="MockFileSystem.Notify" /> before invoking
+	///     <paramref name="triggerAction" /> and counts notifications until either
+	///     the configured timeout elapses or the matching count exceeds the upper
+	///     bound implied by the quantifier. The default timeout is 30 seconds.
+	/// </remarks>
+	public static TriggeredNotificationResult TriggeredNotification(
+		this IThat<MockFileSystem> subject,
+		Func<CancellationToken, Task> triggerAction)
+	{
+		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter filter = new();
+		List<ChangeDescription> captured = new();
+		return new TriggeredNotificationResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint(
+					it, grammars, triggerAction, filter, quantifier, options, captured)),
+			subject,
+			captured,
+			filter,
+			quantifier,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that executing the <paramref name="triggerAction" /> caused the
+	///     <see cref="MockFileSystem.Notify" /> handler to fire.
+	/// </summary>
+	public static TriggeredNotificationResult TriggeredNotification(
+		this IThat<MockFileSystem> subject,
+		Func<Task> triggerAction)
+	{
+		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
+		return TriggeredNotification(subject, _ => triggerAction());
+	}
+
+	/// <summary>
+	///     Verifies that executing the <paramref name="triggerAction" /> did <i>not</i> cause the
+	///     <see cref="MockFileSystem.Notify" /> handler to fire.
+	/// </summary>
+	/// <remarks>
+	///     Configure <c>.Within(...)</c> to limit the wait; otherwise the default 30-second
+	///     timeout applies before the negative outcome is confirmed.
+	/// </remarks>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject,
+		Func<CancellationToken, Task> triggerAction)
+	{
+		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter filter = new();
+		List<ChangeDescription> captured = new();
+		return new DidNotTriggerNotificationResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint(
+					it, grammars, triggerAction, filter, quantifier, options, captured).Invert()),
+			subject,
+			captured,
+			filter,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that executing the <paramref name="triggerAction" /> did <i>not</i> cause the
+	///     <see cref="MockFileSystem.Notify" /> handler to fire.
+	/// </summary>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject,
+		Func<Task> triggerAction)
+	{
+		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
+		return DidNotTriggerNotification(subject, _ => triggerAction());
+	}
+}

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;
@@ -15,28 +14,77 @@ namespace aweXpect.Testably;
 public static partial class FileSystemExtensions
 {
 	/// <summary>
-	///     Verifies that executing the <paramref name="triggerAction" /> caused the
-	///     <see cref="MockFileSystem.Notify" /> handler to fire.
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler fired.
 	/// </summary>
 	/// <remarks>
-	///     Subscribes to <see cref="MockFileSystem.Notify" /> before invoking
-	///     <paramref name="triggerAction" /> and counts notifications until either
-	///     the configured timeout elapses or the matching count exceeds the upper
-	///     bound implied by the quantifier. The default timeout is 30 seconds.
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
+	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
+	///     Combine with <c>.Within(...)</c> to also wait for asynchronous notifications.
+	/// </remarks>
+	public static TriggeredNotificationResult TriggeredNotification(
+		this IThat<MockFileSystem> subject)
+		=> TriggeredNotificationCore(subject, predicate: null, predicateExpression: "");
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler fired for a change
+	///     matching the <paramref name="predicate" />.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
+	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
 	/// </remarks>
 	public static TriggeredNotificationResult TriggeredNotification(
 		this IThat<MockFileSystem> subject,
-		Func<CancellationToken, Task> triggerAction)
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
 	{
-		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate));
+		return TriggeredNotificationCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler did <i>not</i> fire.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so any notification
+	///     that already fired on this <see cref="MockFileSystem" /> fails the assertion. Configure
+	///     <c>.Within(...)</c> to also wait for asynchronous notifications.
+	/// </remarks>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject)
+		=> DidNotTriggerNotificationCore(subject, predicate: null, predicateExpression: "");
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler did <i>not</i> fire for
+	///     any change matching the <paramref name="predicate" />.
+	/// </summary>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+	{
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate));
+		return DidNotTriggerNotificationCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	private static TriggeredNotificationResult TriggeredNotificationCore(
+		IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool>? predicate,
+		string predicateExpression)
+	{
 		Quantifier quantifier = new();
 		NotificationTimeoutOptions options = new();
 		NotificationConstraints.TriggerNotificationFilter filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
 		List<ChangeDescription> captured = new();
 		return new TriggeredNotificationResult(
 			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.TriggeredNotificationConstraint(
-					it, grammars, triggerAction, filter, quantifier, options, captured)),
+					it, grammars, filter, quantifier, options, captured)),
 			subject,
 			captured,
 			filter,
@@ -44,55 +92,28 @@ public static partial class FileSystemExtensions
 			options);
 	}
 
-	/// <summary>
-	///     Verifies that executing the <paramref name="triggerAction" /> caused the
-	///     <see cref="MockFileSystem.Notify" /> handler to fire.
-	/// </summary>
-	public static TriggeredNotificationResult TriggeredNotification(
-		this IThat<MockFileSystem> subject,
-		Func<Task> triggerAction)
+	private static DidNotTriggerNotificationResult DidNotTriggerNotificationCore(
+		IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool>? predicate,
+		string predicateExpression)
 	{
-		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
-		return TriggeredNotification(subject, _ => triggerAction());
-	}
-
-	/// <summary>
-	///     Verifies that executing the <paramref name="triggerAction" /> did <i>not</i> cause the
-	///     <see cref="MockFileSystem.Notify" /> handler to fire.
-	/// </summary>
-	/// <remarks>
-	///     Configure <c>.Within(...)</c> to limit the wait; otherwise the default 30-second
-	///     timeout applies before the negative outcome is confirmed.
-	/// </remarks>
-	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
-		this IThat<MockFileSystem> subject,
-		Func<CancellationToken, Task> triggerAction)
-	{
-		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
 		Quantifier quantifier = new();
 		NotificationTimeoutOptions options = new();
 		NotificationConstraints.TriggerNotificationFilter filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
 		List<ChangeDescription> captured = new();
 		return new DidNotTriggerNotificationResult(
 			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new NotificationConstraints.TriggeredNotificationConstraint(
-					it, grammars, triggerAction, filter, quantifier, options, captured,
+					it, grammars, filter, quantifier, options, captured,
 					exitOnFirstMatch: true).Invert()),
 			subject,
 			captured,
 			filter,
 			options);
-	}
-
-	/// <summary>
-	///     Verifies that executing the <paramref name="triggerAction" /> did <i>not</i> cause the
-	///     <see cref="MockFileSystem.Notify" /> handler to fire.
-	/// </summary>
-	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
-		this IThat<MockFileSystem> subject,
-		Func<Task> triggerAction)
-	{
-		_ = triggerAction ?? throw new ArgumentNullException(nameof(triggerAction));
-		return DidNotTriggerNotification(subject, _ => triggerAction());
 	}
 }

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Helpers;
+
+internal static class NotificationConstraints
+{
+	internal sealed class TriggeredNotificationConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<CancellationToken, Task> action,
+		TriggerNotificationFilter filter,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options,
+		List<ChangeDescription> captured)
+		: ConstraintResult.WithValue<MockFileSystem>(grammars),
+			IAsyncConstraint<MockFileSystem>
+	{
+		private Exception? _actionException;
+
+		public async Task<ConstraintResult> IsMetBy(MockFileSystem actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			TimeSpan timeout = options.Timeout > TimeSpan.Zero ? options.Timeout : TimeSpan.FromSeconds(30);
+			TaskCompletionSource<bool> earlyExit = new();
+			object lockObj = new();
+
+			using CancellationTokenSource deadlineCts =
+				CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			deadlineCts.CancelAfter(timeout);
+			CancellationToken deadlineToken = deadlineCts.Token;
+
+			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEvent(
+				change =>
+				{
+					lock (lockObj)
+					{
+						captured.Add(change);
+						if (quantifier.Check(captured.Count, false) == false)
+						{
+							earlyExit.TrySetResult(false);
+						}
+					}
+				},
+				filter.IsMatch);
+
+			try
+			{
+				await action(deadlineToken).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException) when (deadlineToken.IsCancellationRequested)
+			{
+				// Deadline expired during the trigger action; evaluate what was captured so far.
+			}
+			catch (Exception ex)
+			{
+				_actionException = ex;
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			if (!deadlineToken.IsCancellationRequested && !earlyExit.Task.IsCompleted)
+			{
+				await Task.WhenAny(
+					earlyExit.Task,
+					Task.Delay(Timeout.InfiniteTimeSpan, deadlineToken)).ConfigureAwait(false);
+			}
+
+			int finalCount;
+			lock (lockObj)
+			{
+				finalCount = captured.Count;
+			}
+
+			Outcome = quantifier.Check(finalCount, true) == true ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("triggered a notification");
+			stringBuilder.Append(filter);
+			stringBuilder.Append(' ').Append(quantifier);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder, indentation);
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("did not trigger a notification");
+			stringBuilder.Append(filter);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder, indentation);
+
+		private void AppendCount(StringBuilder stringBuilder, string? indentation)
+		{
+			if (_actionException is not null)
+			{
+				stringBuilder.Append(it).Append(" threw ");
+				Formatter.Format(stringBuilder, _actionException.GetType());
+				stringBuilder.Append(": ").Append(_actionException.Message);
+				return;
+			}
+
+			int count;
+			ChangeDescription[] snapshot;
+			lock (captured)
+			{
+				count = captured.Count;
+				snapshot = captured.ToArray();
+			}
+
+			stringBuilder.Append(it).Append(" was ");
+			if (count == 0)
+			{
+				stringBuilder.Append("not triggered");
+				return;
+			}
+
+			stringBuilder.Append("triggered ");
+			AppendTimes(stringBuilder, count);
+			stringBuilder.Append(" in [");
+			for (int i = 0; i < snapshot.Length; i++)
+			{
+				if (i > 0)
+				{
+					stringBuilder.Append(',');
+				}
+
+				stringBuilder.Append(Environment.NewLine).Append("  ").Append(snapshot[i]);
+			}
+
+			stringBuilder.Append(Environment.NewLine).Append(']');
+		}
+
+		private static void AppendTimes(StringBuilder stringBuilder, int count)
+		{
+			switch (count)
+			{
+				case 1:
+					stringBuilder.Append("once");
+					break;
+				case 2:
+					stringBuilder.Append("twice");
+					break;
+				default:
+					stringBuilder.Append(count).Append(" times");
+					break;
+			}
+		}
+	}
+
+	internal sealed class TriggerNotificationFilter
+	{
+		private readonly List<Func<ChangeDescription, bool>> _predicates = new();
+		private readonly StringBuilder _toString = new();
+
+		public void Add(Func<ChangeDescription, bool> predicate, string predicateExpression)
+		{
+			_predicates.Add(predicate ?? throw new ArgumentNullException(nameof(predicate)));
+			_toString.Append(_predicates.Count == 1 ? " matching " : " and ").Append(predicateExpression.Trim());
+		}
+
+		public bool IsMatch(ChangeDescription change)
+			=> _predicates.All(p => p(change));
+
+		public override string ToString() => _toString.ToString();
+	}
+
+	internal sealed class HasChangeTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		WatcherChangeTypes expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.ChangeType & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has change type ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.ChangeType);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have change type ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasFileSystemTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		FileSystemTypes expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.FileSystemType & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has file system type ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.FileSystemType);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have file system type ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasNotifyFiltersConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		NotifyFilters expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.NotifyFilters & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has notify filters ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.NotifyFilters);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have notify filters ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasStringPropertyConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<ChangeDescription, string?> selector,
+		StringEqualityOptions options,
+		string? expected,
+		string propertyName)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IAsyncConstraint<ChangeDescription>
+	{
+		private string? _actualValue;
+
+		public async Task<ConstraintResult> IsMetBy(ChangeDescription actual,
+			CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualValue = selector(actual);
+			Outcome = await options.AreConsideredEqual(_actualValue, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualValue, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -18,7 +18,6 @@ internal static class NotificationConstraints
 	internal sealed class TriggeredNotificationConstraint(
 		string it,
 		ExpectationGrammars grammars,
-		Func<CancellationToken, Task> action,
 		TriggerNotificationFilter filter,
 		Quantifier quantifier,
 		NotificationTimeoutOptions options,
@@ -27,8 +26,6 @@ internal static class NotificationConstraints
 		: ConstraintResult.WithValue<MockFileSystem>(grammars),
 			IAsyncConstraint<MockFileSystem>
 	{
-		private Exception? _actionException;
-
 		public async Task<ConstraintResult> IsMetBy(MockFileSystem actual, CancellationToken cancellationToken)
 		{
 			Actual = actual;
@@ -46,7 +43,7 @@ internal static class NotificationConstraints
 			deadlineCts.CancelAfter(timeout);
 			CancellationToken deadlineToken = deadlineCts.Token;
 
-			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEvent(
+			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEventOrReplay(
 				change =>
 				{
 					lock (captured)
@@ -59,21 +56,6 @@ internal static class NotificationConstraints
 					}
 				},
 				filter.IsMatch);
-
-			try
-			{
-				await action(deadlineToken).ConfigureAwait(false);
-			}
-			catch (OperationCanceledException) when (deadlineToken.IsCancellationRequested)
-			{
-				// Deadline expired during the trigger action; evaluate what was captured so far.
-			}
-			catch (Exception ex)
-			{
-				_actionException = ex;
-				Outcome = Outcome.Failure;
-				return this;
-			}
 
 			if (!deadlineToken.IsCancellationRequested && !earlyExit.Task.IsCompleted)
 			{
@@ -115,14 +97,6 @@ internal static class NotificationConstraints
 
 		private void AppendCount(StringBuilder stringBuilder, string? indentation)
 		{
-			if (_actionException is not null)
-			{
-				stringBuilder.Append(it).Append(" threw ");
-				Formatter.Format(stringBuilder, _actionException.GetType());
-				stringBuilder.Append(": ").Append(_actionException.Message);
-				return;
-			}
-
 			int count;
 			ChangeDescription[] snapshot;
 			lock (captured)

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -22,7 +22,8 @@ internal static class NotificationConstraints
 		TriggerNotificationFilter filter,
 		Quantifier quantifier,
 		NotificationTimeoutOptions options,
-		List<ChangeDescription> captured)
+		List<ChangeDescription> captured,
+		bool exitOnFirstMatch = false)
 		: ConstraintResult.WithValue<MockFileSystem>(grammars),
 			IAsyncConstraint<MockFileSystem>
 	{
@@ -37,9 +38,8 @@ internal static class NotificationConstraints
 				return this;
 			}
 
-			TimeSpan timeout = options.Timeout > TimeSpan.Zero ? options.Timeout : TimeSpan.FromSeconds(30);
+			TimeSpan timeout = options.Timeout;
 			TaskCompletionSource<bool> earlyExit = new();
-			object lockObj = new();
 
 			using CancellationTokenSource deadlineCts =
 				CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -49,10 +49,10 @@ internal static class NotificationConstraints
 			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEvent(
 				change =>
 				{
-					lock (lockObj)
+					lock (captured)
 					{
 						captured.Add(change);
-						if (quantifier.Check(captured.Count, false) == false)
+						if (exitOnFirstMatch || quantifier.Check(captured.Count, false) == false)
 						{
 							earlyExit.TrySetResult(false);
 						}
@@ -83,7 +83,7 @@ internal static class NotificationConstraints
 			}
 
 			int finalCount;
-			lock (lockObj)
+			lock (captured)
 			{
 				finalCount = captured.Count;
 			}

--- a/Source/aweXpect.Testably/Helpers/NotificationTimeoutOptions.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationTimeoutOptions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace aweXpect.Testably.Helpers;
+
+internal sealed class NotificationTimeoutOptions
+{
+	public TimeSpan Timeout { get; private set; } = TimeSpan.FromSeconds(30);
+
+	public bool IsExplicit { get; private set; }
+
+	public void Within(TimeSpan timeout)
+	{
+		if (timeout < TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), "The timeout must not be negative.");
+		}
+
+		Timeout = timeout;
+		IsExplicit = true;
+	}
+
+	public override string ToString()
+		=> IsExplicit ? $" within {Formatter.Format(Timeout)}" : "";
+}

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Results;
 using aweXpect.Testably.Helpers;
@@ -11,7 +10,7 @@ using Testably.Abstractions.Testing.FileSystem;
 namespace aweXpect.Testably.Results;
 
 /// <summary>
-///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(IThat{MockFileSystem}, Func{Task})" />.
+///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(IThat{MockFileSystem})" />.
 /// </summary>
 public class DidNotTriggerNotificationResult
 	: AndOrResult<MockFileSystem, IThat<MockFileSystem>, DidNotTriggerNotificationResult>

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(aweXpect.Core.IThat{Testably.Abstractions.Testing.MockFileSystem},System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task})" />.
+/// </summary>
+public class DidNotTriggerNotificationResult
+	: AndOrResult<MockFileSystem, IThat<MockFileSystem>, DidNotTriggerNotificationResult>
+{
+	private readonly IReadOnlyList<ChangeDescription> _captured;
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal DidNotTriggerNotificationResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<MockFileSystem> subject,
+		IReadOnlyList<ChangeDescription> captured,
+		NotificationConstraints.TriggerNotificationFilter filter,
+		NotificationTimeoutOptions options)
+		: base(expectationBuilder, subject)
+	{
+		_expectationBuilder = expectationBuilder;
+		_captured = captured;
+		_filter = filter;
+		_options = options;
+	}
+
+	/// <summary>
+	///     Further expectations on the list of <see cref="ChangeDescription" />s captured during the trigger action.
+	/// </summary>
+	public IThat<IReadOnlyList<ChangeDescription>> Which
+		=> new ThatSubject<IReadOnlyList<ChangeDescription>>(
+			_expectationBuilder.ForWhich<MockFileSystem, IReadOnlyList<ChangeDescription>>(
+				_ => _captured, " which "));
+
+	/// <summary>
+	///     Restricts the trigger expectation to notifications matching the <paramref name="predicate" />.
+	/// </summary>
+	public DidNotTriggerNotificationResult Matching(
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		_filter.Add(predicate, doNotPopulateThisValue);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for the trigger action plus subsequent notifications.
+	/// </summary>
+	public DidNotTriggerNotificationResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Results;
 using aweXpect.Testably.Helpers;
@@ -10,7 +11,7 @@ using Testably.Abstractions.Testing.FileSystem;
 namespace aweXpect.Testably.Results;
 
 /// <summary>
-///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(aweXpect.Core.IThat{Testably.Abstractions.Testing.MockFileSystem},System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task})" />.
+///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(IThat{MockFileSystem}, Func{Task})" />.
 /// </summary>
 public class DidNotTriggerNotificationResult
 	: AndOrResult<MockFileSystem, IThat<MockFileSystem>, DidNotTriggerNotificationResult>

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -12,7 +11,7 @@ using Testably.Abstractions.Testing.FileSystem;
 namespace aweXpect.Testably.Results;
 
 /// <summary>
-///     The result for <see cref="FileSystemExtensions.TriggeredNotification(IThat{MockFileSystem}, Func{Task})" />.
+///     The result for <see cref="FileSystemExtensions.TriggeredNotification(IThat{MockFileSystem})" />.
 /// </summary>
 public class TriggeredNotificationResult
 	: CountResult<MockFileSystem, IThat<MockFileSystem>, TriggeredNotificationResult>

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -11,7 +12,7 @@ using Testably.Abstractions.Testing.FileSystem;
 namespace aweXpect.Testably.Results;
 
 /// <summary>
-///     The result for <see cref="FileSystemExtensions.TriggeredNotification(aweXpect.Core.IThat{Testably.Abstractions.Testing.MockFileSystem},System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task})" />.
+///     The result for <see cref="FileSystemExtensions.TriggeredNotification(IThat{MockFileSystem}, Func{Task})" />.
 /// </summary>
 public class TriggeredNotificationResult
 	: CountResult<MockFileSystem, IThat<MockFileSystem>, TriggeredNotificationResult>

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemExtensions.TriggeredNotification(aweXpect.Core.IThat{Testably.Abstractions.Testing.MockFileSystem},System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task})" />.
+/// </summary>
+public class TriggeredNotificationResult
+	: CountResult<MockFileSystem, IThat<MockFileSystem>, TriggeredNotificationResult>
+{
+	private readonly IReadOnlyList<ChangeDescription> _captured;
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal TriggeredNotificationResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<MockFileSystem> subject,
+		IReadOnlyList<ChangeDescription> captured,
+		NotificationConstraints.TriggerNotificationFilter filter,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options)
+		: base(expectationBuilder, subject, quantifier)
+	{
+		_expectationBuilder = expectationBuilder;
+		_captured = captured;
+		_filter = filter;
+		_options = options;
+	}
+
+	/// <summary>
+	///     Further expectations on the list of <see cref="ChangeDescription" />s captured during the trigger action.
+	/// </summary>
+	public IThat<IReadOnlyList<ChangeDescription>> Which
+		=> new ThatSubject<IReadOnlyList<ChangeDescription>>(
+			_expectationBuilder.ForWhich<MockFileSystem, IReadOnlyList<ChangeDescription>>(
+				_ => _captured, " which "));
+
+	/// <summary>
+	///     Restricts the trigger expectation to notifications matching the <paramref name="predicate" />.
+	/// </summary>
+	public TriggeredNotificationResult Matching(
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		_filter.Add(predicate, doNotPopulateThisValue);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for the trigger action plus subsequent notifications.
+	/// </summary>
+	public TriggeredNotificationResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/aweXpect.Testably.csproj
+++ b/Source/aweXpect.Testably/aweXpect.Testably.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="aweXpect.Core"/>
 		<PackageReference Include="Testably.Abstractions.Interface"/>
+		<PackageReference Include="Testably.Abstractions.Testing"/>
 	</ItemGroup>
 
 </Project>

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -46,6 +59,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -54,10 +69,18 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -95,5 +118,11 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -59,8 +59,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -69,8 +69,8 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -36,6 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -44,10 +59,18 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -85,5 +108,11 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -49,8 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -59,8 +59,8 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -36,6 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -44,10 +59,18 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -85,5 +108,11 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Core.IThat<System.Collections.Generic.IReadOnlyList<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> Which { get; }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Matching(System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -49,8 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -59,8 +59,8 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.Tasks.Task> triggerAction) { }
-        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> triggerAction) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasChangeType
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task DoesNotHaveChangeType_WhenChangeTypeDiffers_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveChangeType(WatcherChangeTypes.Deleted);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenChangeTypeDiffers_ShouldFail()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(WatcherChangeTypes.Deleted);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             has change type Deleted,
+					             but it was Created
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenChangeTypeMatches_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(WatcherChangeTypes.Created);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
@@ -12,7 +12,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task DoesNotHaveChangeType_WhenChangeTypeDiffers_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -25,7 +25,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenChangeTypeDiffers_ShouldFail()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -43,7 +43,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenChangeTypeMatches_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasChangeType.Tests.cs
@@ -23,6 +23,20 @@ public sealed partial class ChangeDescription
 			}
 
 			[Fact]
+			public async Task DoesNotHaveChangeType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveChangeType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
 			public async Task WhenChangeTypeDiffers_ShouldFail()
 			{
 				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
@@ -51,6 +65,20 @@ public sealed partial class ChangeDescription
 				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
 			}
 		}
 	}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
@@ -23,6 +23,34 @@ public sealed partial class ChangeDescription
 			}
 
 			[Fact]
+			public async Task DoesNotHaveFileSystemType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveFileSystemType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
+
+			[Fact]
 			public async Task WhenFileSystemTypeDiffers_ShouldFail()
 			{
 				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
@@ -12,7 +12,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task DoesNotHaveFileSystemType_WhenItDiffers_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -25,7 +25,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenFileSystemTypeDiffers_ShouldFail()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -43,7 +43,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenFileSystemTypeMatches_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasFileSystemType.Tests.cs
@@ -1,0 +1,57 @@
+using Testably.Abstractions.Testing;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasFileSystemType
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task DoesNotHaveFileSystemType_WhenItDiffers_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveFileSystemType(FileSystemTypes.Directory);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFileSystemTypeDiffers_ShouldFail()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(FileSystemTypes.Directory);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             has file system type Directory,
+					             but it was File
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFileSystemTypeMatches_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(FileSystemTypes.File);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasName.Tests.cs
@@ -11,7 +11,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenNameDiffers_ShouldFail()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -25,7 +25,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenNameMatches_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasName.Tests.cs
@@ -1,0 +1,39 @@
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNameDiffers_ShouldFail()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasName("bar.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has name equal to \"bar.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNameMatches_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasName(change.Name);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
@@ -10,9 +10,37 @@ public sealed partial class ChangeDescription
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenFlagIsMissing_ShouldSucceed()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(NotifyFilters.Security);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenFlagIsPresent_ShouldFail()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+				NotifyFilters present = change.NotifyFilters;
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(present);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*does not have notify filters*").AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenContainingExpectedFlag_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 				NotifyFilters expected = change.NotifyFilters;
 
 				async Task Act()
@@ -26,7 +54,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenMissingExpectedFlag_ShouldFail()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasNotifyFilters
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenContainingExpectedFlag_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				NotifyFilters expected = change.NotifyFilters;
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(expected);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMissingExpectedFlag_ShouldFail()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(NotifyFilters.Security);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has notify filters Security*").AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasNotifyFilters.Tests.cs
@@ -38,6 +38,20 @@ public sealed partial class ChangeDescription
 			}
 
 			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
 			public async Task WhenContainingExpectedFlag_ShouldSucceed()
 			{
 				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
@@ -49,6 +63,20 @@ public sealed partial class ChangeDescription
 				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldName.Tests.cs
@@ -11,6 +11,45 @@ public sealed partial class ChangeDescription
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenOldNameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				TFsChangeDescription? renamed = null;
+				using IAwaitableCallback<TFsChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldName("other-name.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old name equal to \"other-name.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldNameIsNull_AndExpectedIsNotNull_ShouldFail()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasOldName("foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old name equal to \"foo.txt\"*").AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenOldNameMatches_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldName.Tests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using Testably.Abstractions.Testing;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasOldName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenOldNameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				TFsChangeDescription? renamed = null;
+				using IAwaitableCallback<TFsChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldName(renamed!.OldName!);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldPath.Tests.cs
@@ -11,6 +11,45 @@ public sealed partial class ChangeDescription
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenOldPathDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				TFsChangeDescription? renamed = null;
+				using IAwaitableCallback<TFsChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldPath("totally-different-path");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old path equal to \"totally-different-path\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldPathIsNull_AndExpectedIsNotNull_ShouldFail()
+			{
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasOldPath("foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old path equal to \"foo.txt\"*").AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenOldPathMatches_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasOldPath.Tests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using Testably.Abstractions.Testing;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasOldPath
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenOldPathMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				TFsChangeDescription? renamed = null;
+				using IAwaitableCallback<TFsChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldPath(renamed!.OldPath!);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasPath.Tests.cs
@@ -11,7 +11,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenPathDiffers_ShouldFail()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{
@@ -25,7 +25,7 @@ public sealed partial class ChangeDescription
 			[Fact]
 			public async Task WhenPathMatches_ShouldSucceed()
 			{
-				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+				TFsChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.HasPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.HasPath.Tests.cs
@@ -1,0 +1,39 @@
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	public sealed class HasPath
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPathDiffers_ShouldFail()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasPath("totally-different-path");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has path equal to \"totally-different-path\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPathMatches_ShouldSucceed()
+			{
+				TFsChangeDescription change = await CaptureAsync(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasPath(change.Path);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.cs
@@ -9,7 +9,7 @@ public sealed partial class ChangeDescription
 	///     Runs <paramref name="trigger" /> on a fresh <see cref="MockFileSystem" /> and returns
 	///     the first <see cref="TFsChangeDescription" /> that fired during it.
 	/// </summary>
-	internal static Task<TFsChangeDescription> CaptureAsync(Action<MockFileSystem> trigger)
+	internal static TFsChangeDescription Capture(Action<MockFileSystem> trigger)
 	{
 		MockFileSystem fileSystem = new();
 		TFsChangeDescription? captured = null;
@@ -20,6 +20,6 @@ public sealed partial class ChangeDescription
 			throw new InvalidOperationException("No notification was captured during the trigger action.");
 		}
 
-		return Task.FromResult(captured);
+		return captured;
 	}
 }

--- a/Tests/aweXpect.Testably.Tests/ChangeDescription.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescription.cs
@@ -1,0 +1,25 @@
+using Testably.Abstractions.Testing;
+using TFsChangeDescription = Testably.Abstractions.Testing.FileSystem.ChangeDescription;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescription
+{
+	/// <summary>
+	///     Runs <paramref name="trigger" /> on a fresh <see cref="MockFileSystem" /> and returns
+	///     the first <see cref="TFsChangeDescription" /> that fired during it.
+	/// </summary>
+	internal static Task<TFsChangeDescription> CaptureAsync(Action<MockFileSystem> trigger)
+	{
+		MockFileSystem fileSystem = new();
+		TFsChangeDescription? captured = null;
+		using IAwaitableCallback<TFsChangeDescription> registration = fileSystem.Notify.OnEvent(c => captured ??= c);
+		trigger(fileSystem);
+		if (captured is null)
+		{
+			throw new InvalidOperationException("No notification was captured during the trigger action.");
+		}
+
+		return Task.FromResult(captured);
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileInfo.HasCreationTime.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.HasCreationTime.Tests.cs
@@ -34,13 +34,13 @@ public sealed partial class FileInfo
 			}
 
 			[Fact]
-			public async Task WhenCreationTimeMatches_ShouldSucceed()
+			public async Task WhenCreationTimeIsUnspecified_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();
-				DateTime expected = CurrentTime().ToUniversalTime();
+				DateTime expected = new(2020, 2, 1, 12, 0, 0, DateTimeKind.Unspecified);
 				string path = "foo.txt";
 				fileSystem.File.WriteAllText(path, "");
-				fileSystem.File.SetCreationTimeUtc(path, expected);
+				fileSystem.File.SetCreationTime(path, expected);
 				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
 
 				async Task Act()
@@ -52,13 +52,13 @@ public sealed partial class FileInfo
 			}
 
 			[Fact]
-			public async Task WhenCreationTimeIsUnspecified_ShouldSucceed()
+			public async Task WhenCreationTimeMatches_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();
-				DateTime expected = new(2020, 2, 1, 12, 0, 0, DateTimeKind.Unspecified);
+				DateTime expected = CurrentTime().ToUniversalTime();
 				string path = "foo.txt";
 				fileSystem.File.WriteAllText(path, "");
-				fileSystem.File.SetCreationTime(path, expected);
+				fileSystem.File.SetCreationTimeUtc(path, expected);
 				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
 
 				async Task Act()

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed class DidNotTriggerNotification
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenActionDoesNotTrigger_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification(ct =>
+					{
+						bool _ = sut.Directory.Exists("/");
+						return Task.CompletedTask;
+					}).Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenActionTriggers_ShouldFail()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification(_ =>
+					{
+						sut.File.WriteAllText("foo.txt", "x");
+						return Task.CompletedTask;
+					}).Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*did not trigger a notification*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithMatchingPredicate_WhenOnlyNonMatchingTriggered_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification(_ =>
+						{
+							sut.File.WriteAllText("foo.txt", "x");
+							return Task.CompletedTask;
+						}).Matching(c => c.ChangeType == WatcherChangeTypes.Deleted)
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
@@ -10,35 +9,24 @@ public sealed partial class FileSystem
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenActionDoesNotTrigger_ShouldSucceed()
+			public async Task WhenNoPriorEvent_ShouldSucceed()
 			{
 				MockFileSystem sut = new();
 
 				async Task Act()
-				{
-					await That(sut).DidNotTriggerNotification(ct =>
-					{
-						bool _ = sut.Directory.Exists("/");
-						return Task.CompletedTask;
-					}).Within(TimeSpan.FromMilliseconds(100));
-				}
+					=> await That(sut).DidNotTriggerNotification().Within(TimeSpan.FromMilliseconds(100));
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenActionTriggers_ShouldFail()
+			public async Task WhenPriorEventExists_ShouldFailSynchronously()
 			{
 				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
-				{
-					await That(sut).DidNotTriggerNotification(_ =>
-					{
-						sut.File.WriteAllText("foo.txt", "x");
-						return Task.CompletedTask;
-					}).Within(TimeSpan.FromMilliseconds(100));
-				}
+					=> await That(sut).DidNotTriggerNotification();
 
 				await That(Act).ThrowsException()
 					.WithMessage("*did not trigger a notification*")
@@ -46,21 +34,30 @@ public sealed partial class FileSystem
 			}
 
 			[Fact]
-			public async Task WithMatchingPredicate_WhenOnlyNonMatchingTriggered_ShouldSucceed()
+			public async Task WithPredicate_WhenNoMatchingPriorEvent_ShouldSucceed()
 			{
 				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
-				{
-					await That(sut).DidNotTriggerNotification(_ =>
-						{
-							sut.File.WriteAllText("foo.txt", "x");
-							return Task.CompletedTask;
-						}).Matching(c => c.ChangeType == WatcherChangeTypes.Deleted)
+					=> await That(sut).DidNotTriggerNotification(c => c.Name == "other.txt")
 						.Within(TimeSpan.FromMilliseconds(100));
-				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenMatchingPriorEvent_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+					=> await That(sut).DidNotTriggerNotification(c => c.Name == "foo.txt");
+
+				await That(Act).ThrowsException()
+					.WithMessage("*did not trigger a notification*")
+					.AsWildcard();
 			}
 		}
 	}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDirectory.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDirectory.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveFile.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveFile.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithDirectories.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithDirectories.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WhoseContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WhoseContent.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.EqualTo.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.EqualTo.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotEqualTo.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotSameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotSameAs.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.SameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.SameAs.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using aweXpect.Core;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed class TriggeredNotification
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenActionTriggersOnce_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(_ =>
+					{
+						sut.File.WriteAllText("foo.txt", "x");
+						return Task.CompletedTask;
+					});
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMatchingPredicateNeverTriggers_ShouldFail()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(_ =>
+						{
+							sut.File.WriteAllText("foo.txt", "x");
+							return Task.CompletedTask;
+						}).Matching(c => c.ChangeType == WatcherChangeTypes.Deleted)
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered a notification*matching*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhichExposesCapturedChanges()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(_ =>
+					{
+						sut.File.WriteAllText("foo.txt", "x");
+						return Task.CompletedTask;
+					}).Which.IsNotEmpty();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithExactlyOnce_WhenTriggeredOnce_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(_ =>
+						{
+							sut.File.WriteAllText("foo.txt", "x");
+							return Task.CompletedTask;
+						}).Matching(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(_ =>
+						{
+							sut.File.WriteAllText("a.txt", "x");
+							sut.File.WriteAllText("b.txt", "x");
+							return Task.CompletedTask;
+						}).Matching(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered twice*")
+					.AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -11,36 +11,50 @@ public sealed partial class FileSystem
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenActionTriggersOnce_ShouldSucceed()
+			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
 			{
 				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
 
-				async Task Act()
-				{
-					await That(sut).TriggeredNotification(_ =>
-					{
-						sut.File.WriteAllText("foo.txt", "x");
-						return Task.CompletedTask;
-					});
-				}
+				async Task Act() => await That(sut).TriggeredNotification();
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenMatchingPredicateNeverTriggers_ShouldFail()
+			public async Task WhenNoPriorEvent_ShouldFailAfterTimeout()
 			{
 				MockFileSystem sut = new();
 
 				async Task Act()
-				{
-					await That(sut).TriggeredNotification(_ =>
-						{
-							sut.File.WriteAllText("foo.txt", "x");
-							return Task.CompletedTask;
-						}).Matching(c => c.ChangeType == WatcherChangeTypes.Deleted)
+					=> await That(sut).TriggeredNotification().Within(TimeSpan.FromMilliseconds(100));
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered a notification*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+					=> await That(sut).TriggeredNotification(c => c.Name == "foo.txt");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+					=> await That(sut).TriggeredNotification(c => c.Name == "other.txt")
 						.Within(TimeSpan.FromMilliseconds(100));
-				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("*triggered a notification*matching*")
@@ -48,36 +62,43 @@ public sealed partial class FileSystem
 			}
 
 			[Fact]
-			public async Task WhichExposesCapturedChanges()
+			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
 
 				async Task Act()
-				{
-					await That(sut).TriggeredNotification(_ =>
-					{
-						sut.File.WriteAllText("foo.txt", "x");
-						return Task.CompletedTask;
-					}).Which.IsNotEmpty();
-				}
+					=> await That(sut).TriggeredNotification().Within(TimeSpan.FromSeconds(2));
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WithExactlyOnce_WhenTriggeredOnce_ShouldSucceed()
+			public async Task WhichExposesCapturedChanges()
 			{
 				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
-				{
-					await That(sut).TriggeredNotification(_ =>
-						{
-							sut.File.WriteAllText("foo.txt", "x");
-							return Task.CompletedTask;
-						}).Matching(c => c.ChangeType == WatcherChangeTypes.Created)
+					=> await That(sut).TriggeredNotification().Which.IsNotEmpty();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithMatching_NarrowsAssertion()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+					=> await That(sut).TriggeredNotification()
+						.Matching(c => c.ChangeType == WatcherChangeTypes.Created)
 						.Exactly(1.Times());
-				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -86,18 +107,14 @@ public sealed partial class FileSystem
 			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
 			{
 				MockFileSystem sut = new();
+				sut.File.WriteAllText("a.txt", "x");
+				sut.File.WriteAllText("b.txt", "x");
 
 				async Task Act()
-				{
-					await That(sut).TriggeredNotification(_ =>
-						{
-							sut.File.WriteAllText("a.txt", "x");
-							sut.File.WriteAllText("b.txt", "x");
-							return Task.CompletedTask;
-						}).Matching(c => c.ChangeType == WatcherChangeTypes.Created)
+					=> await That(sut).TriggeredNotification()
+						.Matching(c => c.ChangeType == WatcherChangeTypes.Created)
 						.Exactly(1.Times())
 						.Within(TimeSpan.FromMilliseconds(100));
-				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("*triggered twice*")


### PR DESCRIPTION
Adds expectations for the `MockFileSystem.Notify` post-change notification system:

- `That(fs).TriggeredNotification(triggerAction)` with `.Matching`, `.Within`, `.Which`, and the standard count selectors (`Exactly`, `AtLeast`, `Once`, ...). The trigger action is `Func<CancellationToken, Task>` with a `Func<Task>` overload.
- `That(fs).DidNotTriggerNotification(triggerAction)` with `.Matching`, `.Within`, `.Which`.
- Subject extensions on `ChangeDescription`: `HasChangeType`, `HasFileSystemType`, `HasNotifyFilters` (flag containment) plus `HasPath`, `HasName`, `HasOldPath`, `HasOldName` (string equality).

Default timeout is 30 seconds for both positive and negative trigger assertions. Captured `ChangeDescription`s are exposed via `.Which` so further collection-level assertions can be chained.

Pulls in `Testably.Abstractions.Testing` as a package dependency since the notification handler types live there.