### PR TITLE
feat: add notification and ChangeDescription assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.32.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
-		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
-		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.0.0"/>
+		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.2.0"/>
+		<PackageVersion Include="Testably.Abstractions.Testing" Version="6.4.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/README.md
+++ b/README.md
@@ -105,3 +105,82 @@ same assertions light up in both places:
 await That(fileSystem).HasFile("my-file.txt").Which.HasLength(12).And.HasContent("some content");
 await That(fileSystem).HasDirectory("logs").Which.IsEmpty();
 ```
+
+### Notifications
+
+A `MockFileSystem` raises notifications when files or directories change. Run
+the code under test, then assert against the notifications it produced:
+
+```csharp
+MockFileSystem fileSystem = new();
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(fileSystem).TriggeredNotification();
+await That(fileSystem).TriggeredNotification(c => c.Name == "my-file.txt");
+```
+
+`.Within(timeout)` (default 30 s) lets the assertion wait for asynchronous
+notifications — if a matching notification already fired the assertion
+completes synchronously, otherwise it waits up to the timeout for a late
+arrival:
+
+```csharp
+_ = Task.Run(() => fileSystem.File.WriteAllText("foo.txt", "x"));
+await That(fileSystem).TriggeredNotification().Within(100.Milliseconds());
+```
+
+`DidNotTriggerNotification` mirrors the same shapes and short-circuits as soon
+as a matching notification is observed:
+
+```csharp
+await That(fileSystem).DidNotTriggerNotification().Within(100.Milliseconds());
+await That(fileSystem).DidNotTriggerNotification(c => c.Name == "secret.txt");
+```
+
+`TriggeredNotification` accepts a `Quantifier` (`AtLeast`, `AtMost`, `Exactly`,
+`Between`, `Never`, `Once`) so you can assert how often the notification fires:
+
+```csharp
+fileSystem.File.WriteAllText("a.txt", "x");
+fileSystem.File.WriteAllText("b.txt", "y");
+
+await That(fileSystem).TriggeredNotification(c => c.ChangeType == WatcherChangeTypes.Created)
+    .Exactly(2.Times());
+```
+
+Both `TriggeredNotification` and `DidNotTriggerNotification` expose
+`.Which(c => …)`, which applies inner expectations from `ChangeDescriptionExtensions`
+as an additional per-notification filter — only changes that satisfy them count:
+
+```csharp
+fileSystem.File.WriteAllText("a.txt", "x");
+
+await That(fileSystem)
+    .TriggeredNotification()
+    .Which(c => c.HasName("a.txt").And.HasChangeType(WatcherChangeTypes.Created))
+    .Exactly(1.Times());
+```
+
+> Replay of historical notifications relies on the `MockFileSystem` notification
+> history. Disable it via
+> `new MockFileSystem(o => o.WithoutNotificationHistory())` only if you don't
+> use these assertions — they throw against a history-disabled file system.
+
+### `ChangeDescription` as a subject
+
+Individual `ChangeDescription` instances can be asserted directly. The
+`HasChangeType`, `HasFileSystemType` and `HasNotifyFilters` assertions use flag
+containment (so a `LastWrite | FileName` change satisfies
+`HasNotifyFilters(NotifyFilters.LastWrite)`); the empty / `default` value is
+rejected with an `ArgumentException` to avoid silent passes.
+
+```csharp
+await That(change).HasChangeType(WatcherChangeTypes.Created);
+await That(change).DoesNotHaveChangeType(WatcherChangeTypes.Deleted);
+
+await That(change).HasFileSystemType(FileSystemTypes.File);
+await That(change).HasNotifyFilters(NotifyFilters.LastWrite);
+
+await That(change).HasName("my-file.txt").And.HasPath("/abs/my-file.txt");
+await That(renamedChange).HasOldName("old.txt").And.HasOldPath("/abs/old.txt");
+```

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="ChangeDescription" />.
+/// </summary>
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="WatcherChangeTypes" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="WatcherChangeTypes" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasChangeType(
+		this IThat<ChangeDescription> source,
+		WatcherChangeTypes expected)
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected change type must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, expected)),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="WatcherChangeTypes" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveChangeType(
+		this IThat<ChangeDescription> source,
+		WatcherChangeTypes unexpected)
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected change type must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, unexpected).Invert()),
+			source);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
@@ -1,0 +1,55 @@
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="FileSystemTypes" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="FileSystemTypes" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasFileSystemType(
+		this IThat<ChangeDescription> source,
+		FileSystemTypes expected)
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected file system type must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, expected)),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="FileSystemTypes" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveFileSystemType(
+		this IThat<ChangeDescription> source,
+		FileSystemTypes unexpected)
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected file system type must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, unexpected).Invert()),
+			source);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
@@ -1,0 +1,30 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="ChangeDescription.Name" /> can be <see langword="null" /> on the underlying
+	///     <see cref="ChangeDescription" />, so <paramref name="expected" /> is nullable too.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasName(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.Name, options, expected, "name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" />
+	///     <see cref="NotifyFilters" />.
+	/// </summary>
+	/// <remarks>
+	///     The check uses flag containment, because <see cref="NotifyFilters" /> is a flag enum.
+	/// </remarks>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasNotifyFilters(
+		this IThat<ChangeDescription> source,
+		NotifyFilters expected)
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected notify filters must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, expected)),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
+	///     <see cref="NotifyFilters" />.
+	/// </summary>
+	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveNotifyFilters(
+		this IThat<ChangeDescription> source,
+		NotifyFilters unexpected)
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected notify filters must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, unexpected).Invert()),
+			source);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
@@ -1,0 +1,30 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> old name.
+	/// </summary>
+	/// <remarks>
+	///     The old name is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change,
+	///     so <see cref="ChangeDescription.OldName" /> is nullable and <paramref name="expected" /> is too.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldName(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.OldName, options, expected, "old name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
@@ -1,0 +1,30 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> old path.
+	/// </summary>
+	/// <remarks>
+	///     The old path is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change,
+	///     so <see cref="ChangeDescription.OldPath" /> is nullable and <paramref name="expected" /> is too.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldPath(
+		this IThat<ChangeDescription> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.OldPath, options, expected, "old path")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
@@ -1,0 +1,30 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class ChangeDescriptionExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ChangeDescription" /> has the <paramref name="expected" /> path.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="ChangeDescription.Path" /> is always set on the underlying
+	///     <see cref="ChangeDescription" />, so <paramref name="expected" /> is non-nullable.
+	/// </remarks>
+	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasPath(
+		this IThat<ChangeDescription> source,
+		string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.HasStringPropertyConstraint(
+					it, grammars, c => c.Path, options, expected, "path")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -19,7 +19,8 @@ public static partial class FileSystemExtensions
 	/// <remarks>
 	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
 	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
-	///     Combine with <c>.Within(...)</c> to also wait for asynchronous notifications.
+	///     The assertion always waits up to a timeout for late-arriving (asynchronous)
+	///     notifications — 30 seconds by default; use <c>.Within(timeout)</c> to override.
 	/// </remarks>
 	public static TriggeredNotificationResult TriggeredNotification(
 		this IThat<MockFileSystem> subject)
@@ -32,6 +33,8 @@ public static partial class FileSystemExtensions
 	/// <remarks>
 	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
 	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
+	///     The assertion always waits up to a timeout for late-arriving (asynchronous)
+	///     notifications — 30 seconds by default; use <c>.Within(timeout)</c> to override.
 	/// </remarks>
 	public static TriggeredNotificationResult TriggeredNotification(
 		this IThat<MockFileSystem> subject,
@@ -52,8 +55,10 @@ public static partial class FileSystemExtensions
 	/// </summary>
 	/// <remarks>
 	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so any notification
-	///     that already fired on this <see cref="MockFileSystem" /> fails the assertion. Configure
-	///     <c>.Within(...)</c> to also wait for asynchronous notifications.
+	///     that already fired on this <see cref="MockFileSystem" /> fails the assertion. The
+	///     assertion also waits up to a timeout for late-arriving notifications — 30 seconds by
+	///     default; use <c>.Within(timeout)</c> to lower it when you do not need to wait. The
+	///     assertion short-circuits as soon as a matching notification is observed.
 	/// </remarks>
 	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
 		this IThat<MockFileSystem> subject)

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Testably.Helpers;
+using aweXpect.Testably.Results;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+public static partial class FileSystemExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler fired.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
+	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
+	///     Combine with <c>.Within(...)</c> to also wait for asynchronous notifications.
+	/// </remarks>
+	public static TriggeredNotificationResult TriggeredNotification(
+		this IThat<MockFileSystem> subject)
+		=> TriggeredNotificationCore(subject, null, "");
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler fired for a change
+	///     matching the <paramref name="predicate" />.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so notifications
+	///     that already fired on this <see cref="MockFileSystem" /> count toward the quantifier.
+	/// </remarks>
+	public static TriggeredNotificationResult TriggeredNotification(
+		this IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		if (predicate is null)
+		{
+			throw new ArgumentNullException(nameof(predicate));
+		}
+
+		return TriggeredNotificationCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler did <i>not</i> fire.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="INotificationHandler.OnEventOrReplay" /> so any notification
+	///     that already fired on this <see cref="MockFileSystem" /> fails the assertion. Configure
+	///     <c>.Within(...)</c> to also wait for asynchronous notifications.
+	/// </remarks>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject)
+		=> DidNotTriggerNotificationCore(subject, null, "");
+
+	/// <summary>
+	///     Verifies that the <see cref="MockFileSystem.Notify" /> handler did <i>not</i> fire for
+	///     any change matching the <paramref name="predicate" />.
+	/// </summary>
+	public static DidNotTriggerNotificationResult DidNotTriggerNotification(
+		this IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		if (predicate is null)
+		{
+			throw new ArgumentNullException(nameof(predicate));
+		}
+
+		return DidNotTriggerNotificationCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	private static TriggeredNotificationResult TriggeredNotificationCore(
+		IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool>? predicate,
+		string predicateExpression)
+	{
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
+		List<ChangeDescription> matches = new();
+		return new TriggeredNotificationResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint(
+					it, grammars, filter, quantifier, options, matches)),
+			subject,
+			quantifier,
+			options,
+			filter);
+	}
+
+	private static DidNotTriggerNotificationResult DidNotTriggerNotificationCore(
+		IThat<MockFileSystem> subject,
+		Func<ChangeDescription, bool>? predicate,
+		string predicateExpression)
+	{
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
+		List<ChangeDescription> matches = new();
+		return new DidNotTriggerNotificationResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint(
+					it, grammars, filter, quantifier, options, matches,
+					true).Invert()),
+			subject,
+			options,
+			filter);
+	}
+}

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -77,6 +77,8 @@ internal static class NotificationConstraints
 					Task.Delay(Timeout.InfiniteTimeSpan, deadlineToken)).ConfigureAwait(false);
 			}
 
+			cancellationToken.ThrowIfCancellationRequested();
+
 			int matchCount;
 			lock (matches)
 			{
@@ -165,24 +167,23 @@ internal static class NotificationConstraints
 	internal sealed class TriggerNotificationFilter
 	{
 		private readonly List<ManualExpectationBuilder<ChangeDescription>> _asyncFilters = new();
-
-		private readonly StringBuilder _description = new();
-		private readonly List<Func<ChangeDescription, bool>> _syncPredicates = new();
+		private readonly List<(Func<ChangeDescription, bool> Predicate, string Description)> _syncPredicates = new();
 
 		public void Add(Func<ChangeDescription, bool> predicate, string predicateExpression)
 		{
-			_syncPredicates.Add(predicate ?? throw new ArgumentNullException(nameof(predicate)));
-			AppendDescription(predicateExpression);
+			if (predicate is null)
+			{
+				throw new ArgumentNullException(nameof(predicate));
+			}
+
+			_syncPredicates.Add((predicate, predicateExpression.Trim()));
 		}
 
-		public void Add(ManualExpectationBuilder<ChangeDescription> builder, string expressionDescription)
-		{
-			_asyncFilters.Add(builder);
-			AppendDescription(expressionDescription);
-		}
+		public void Add(ManualExpectationBuilder<ChangeDescription> builder)
+			=> _asyncFilters.Add(builder);
 
 		public bool IsSyncMatch(ChangeDescription change)
-			=> _syncPredicates.All(p => p(change));
+			=> _syncPredicates.All(p => p.Predicate(change));
 
 		public bool IsAsyncMatchSync(ChangeDescription change,
 			IEvaluationContext context,
@@ -201,11 +202,31 @@ internal static class NotificationConstraints
 			return true;
 		}
 
-		public override string ToString() => _description.ToString();
+		public override string ToString()
+		{
+			if (_syncPredicates.Count == 0 && _asyncFilters.Count == 0)
+			{
+				return "";
+			}
 
-		private void AppendDescription(string text) => _description
-			.Append(_syncPredicates.Count + _asyncFilters.Count == 1 ? " matching " : " and ")
-			.Append(text.Trim());
+			StringBuilder sb = new();
+			bool firstInGroup = true;
+			foreach ((Func<ChangeDescription, bool> _, string description) in _syncPredicates)
+			{
+				sb.Append(firstInGroup ? " matching " : " and ").Append(description);
+				firstInGroup = false;
+			}
+
+			firstInGroup = true;
+			foreach (ManualExpectationBuilder<ChangeDescription> builder in _asyncFilters)
+			{
+				sb.Append(firstInGroup ? " which " : " and ");
+				builder.AppendExpectation(sb, indentation: "");
+				firstInGroup = false;
+			}
+
+			return sb.ToString();
+		}
 	}
 
 	internal sealed class HasChangeTypeConstraint(

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -56,6 +56,11 @@ internal static class NotificationConstraints
 
 					lock (matches)
 					{
+						if (exitOnFirstMatch && matches.Count > 0)
+						{
+							return;
+						}
+
 						matches.Add(change);
 						if (exitOnFirstMatch || quantifier.Check(matches.Count, false) is not null)
 						{

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Options;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Helpers;
+
+internal static class NotificationConstraints
+{
+	internal sealed class TriggeredNotificationConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TriggerNotificationFilter filter,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options,
+		List<ChangeDescription> matches,
+		bool exitOnFirstMatch = false)
+		: ConstraintResult.WithValue<MockFileSystem>(grammars),
+			IAsyncContextConstraint<MockFileSystem>
+	{
+		public async Task<ConstraintResult> IsMetBy(MockFileSystem actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			TimeSpan timeout = options.Timeout;
+			TaskCompletionSource<bool> earlyExit = new();
+
+			using CancellationTokenSource deadlineCts =
+				CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			deadlineCts.CancelAfter(timeout);
+			CancellationToken deadlineToken = deadlineCts.Token;
+
+			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEventOrReplay(
+				change =>
+				{
+					if (!filter.IsAsyncMatchSync(change, context, cancellationToken))
+					{
+						return;
+					}
+
+					lock (matches)
+					{
+						matches.Add(change);
+						if (exitOnFirstMatch || quantifier.Check(matches.Count, false) is not null)
+						{
+							earlyExit.TrySetResult(false);
+						}
+					}
+				},
+				filter.IsSyncMatch);
+
+			if (!deadlineToken.IsCancellationRequested && !earlyExit.Task.IsCompleted)
+			{
+				await Task.WhenAny(
+					earlyExit.Task,
+					Task.Delay(Timeout.InfiniteTimeSpan, deadlineToken)).ConfigureAwait(false);
+			}
+
+			int matchCount;
+			lock (matches)
+			{
+				matchCount = matches.Count;
+			}
+
+			Outcome = quantifier.Check(matchCount, true) == true ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("triggered a notification");
+			stringBuilder.Append(filter);
+			stringBuilder.Append(' ').Append(quantifier);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder);
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("did not trigger a notification");
+			stringBuilder.Append(filter);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder);
+
+		private void AppendCount(StringBuilder stringBuilder)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+				return;
+			}
+
+			ChangeDescription[] snapshot;
+			lock (matches)
+			{
+				snapshot = matches.ToArray();
+			}
+
+			stringBuilder.Append(it).Append(" was ");
+			if (snapshot.Length == 0)
+			{
+				stringBuilder.Append("not triggered");
+				return;
+			}
+
+			stringBuilder.Append("triggered ");
+			AppendTimes(stringBuilder, snapshot.Length);
+			stringBuilder.Append(" in [");
+			for (int i = 0; i < snapshot.Length; i++)
+			{
+				if (i > 0)
+				{
+					stringBuilder.Append(',');
+				}
+
+				stringBuilder.Append(Environment.NewLine).Append("  ").Append(snapshot[i]);
+			}
+
+			stringBuilder.Append(Environment.NewLine).Append(']');
+		}
+
+		private static void AppendTimes(StringBuilder stringBuilder, int count)
+		{
+			switch (count)
+			{
+				case 1:
+					stringBuilder.Append("once");
+					break;
+				case 2:
+					stringBuilder.Append("twice");
+					break;
+				default:
+					stringBuilder.Append(count).Append(" times");
+					break;
+			}
+		}
+	}
+
+	internal sealed class TriggerNotificationFilter
+	{
+		private readonly List<ManualExpectationBuilder<ChangeDescription>> _asyncFilters = new();
+
+		private readonly StringBuilder _description = new();
+		private readonly List<Func<ChangeDescription, bool>> _syncPredicates = new();
+
+		public void Add(Func<ChangeDescription, bool> predicate, string predicateExpression)
+		{
+			_syncPredicates.Add(predicate ?? throw new ArgumentNullException(nameof(predicate)));
+			AppendDescription(predicateExpression);
+		}
+
+		public void Add(ManualExpectationBuilder<ChangeDescription> builder, string expressionDescription)
+		{
+			_asyncFilters.Add(builder);
+			AppendDescription(expressionDescription);
+		}
+
+		public bool IsSyncMatch(ChangeDescription change)
+			=> _syncPredicates.All(p => p(change));
+
+		public bool IsAsyncMatchSync(ChangeDescription change,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			foreach (ManualExpectationBuilder<ChangeDescription> builder in _asyncFilters)
+			{
+				ConstraintResult result = builder.IsMetBy(change, context, cancellationToken)
+					.ConfigureAwait(false).GetAwaiter().GetResult();
+				if (result.Outcome != Outcome.Success)
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		public override string ToString() => _description.ToString();
+
+		private void AppendDescription(string text) => _description
+			.Append(_syncPredicates.Count + _asyncFilters.Count == 1 ? " matching " : " and ")
+			.Append(text.Trim());
+	}
+
+	internal sealed class HasChangeTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		WatcherChangeTypes expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.ChangeType & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has change type ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.ChangeType);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have change type ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasFileSystemTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		FileSystemTypes expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.FileSystemType & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has file system type ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.FileSystemType);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have file system type ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasNotifyFiltersConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		NotifyFilters expected)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IValueConstraint<ChangeDescription>
+	{
+		public ConstraintResult IsMetBy(ChangeDescription actual)
+		{
+			Actual = actual;
+			Outcome = actual != null! && (actual.NotifyFilters & expected) == expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has notify filters ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(Actual.NotifyFilters);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have notify filters ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasStringPropertyConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<ChangeDescription, string?> selector,
+		StringEqualityOptions options,
+		string? expected,
+		string propertyName)
+		: ConstraintResult.WithValue<ChangeDescription>(grammars),
+			IAsyncConstraint<ChangeDescription>
+	{
+		private string? _actualValue;
+
+		public async Task<ConstraintResult> IsMetBy(ChangeDescription actual,
+			CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualValue = selector(actual);
+			Outcome = await options.AreConsideredEqual(_actualValue, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualValue, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/Helpers/NotificationTimeoutOptions.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationTimeoutOptions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace aweXpect.Testably.Helpers;
+
+internal sealed class NotificationTimeoutOptions
+{
+	public TimeSpan Timeout { get; private set; } = TimeSpan.FromSeconds(30);
+
+	public bool IsExplicit { get; private set; }
+
+	public void Within(TimeSpan timeout)
+	{
+		if (timeout < TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), "The timeout must not be negative.");
+		}
+
+		Timeout = timeout;
+		IsExplicit = true;
+	}
+
+	public override string ToString()
+		=> IsExplicit ? $" within {Formatter.Format(Timeout)}" : "";
+}

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemExtensions.DidNotTriggerNotification(aweXpect.Core.IThat{MockFileSystem})" />.
+/// </summary>
+public class DidNotTriggerNotificationResult
+	: AndOrResult<MockFileSystem, IThat<MockFileSystem>, DidNotTriggerNotificationResult>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal DidNotTriggerNotificationResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<MockFileSystem> subject,
+		NotificationTimeoutOptions options,
+		NotificationConstraints.TriggerNotificationFilter filter)
+		: base(expectationBuilder, subject)
+	{
+		_expectationBuilder = expectationBuilder;
+		_options = options;
+		_filter = filter;
+	}
+
+	/// <summary>
+	///     Restricts the assertion to notifications that satisfy the inner <paramref name="expectation" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="expectation" /> is applied as an additional per-change filter, so any
+	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
+	///     <c>.HasChangeType(...)</c>) compose naturally — the assertion fails if any notification
+	///     satisfies all of them.
+	/// </remarks>
+	public DidNotTriggerNotificationResult Which(
+		Action<IThat<ChangeDescription>> expectation,
+		[CallerArgumentExpression("expectation")]
+		string doNotPopulateThisValue = "")
+	{
+		if (expectation is null)
+		{
+			throw new ArgumentNullException(nameof(expectation));
+		}
+
+		ManualExpectationBuilder<ChangeDescription> manualBuilder =
+			new(_expectationBuilder);
+		expectation(new ThatSubject<ChangeDescription>(manualBuilder));
+		_filter.Add(manualBuilder, doNotPopulateThisValue);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for waiting for asynchronous notifications.
+	/// </summary>
+	public DidNotTriggerNotificationResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Results;
 using aweXpect.Testably.Helpers;
@@ -37,22 +36,20 @@ public class DidNotTriggerNotificationResult
 	///     The <paramref name="expectation" /> is applied as an additional per-change filter, so any
 	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
 	///     <c>.HasChangeType(...)</c>) compose naturally — the assertion fails if any notification
-	///     satisfies all of them.
+	///     satisfies all of them. The expectation text is taken from the inner expectation builder,
+	///     so it reads like <c>matching has name equal to "foo.txt"</c> rather than the raw lambda
+	///     source.
 	/// </remarks>
-	public DidNotTriggerNotificationResult Which(
-		Action<IThat<ChangeDescription>> expectation,
-		[CallerArgumentExpression("expectation")]
-		string doNotPopulateThisValue = "")
+	public DidNotTriggerNotificationResult Which(Action<IThat<ChangeDescription>> expectation)
 	{
 		if (expectation is null)
 		{
 			throw new ArgumentNullException(nameof(expectation));
 		}
 
-		ManualExpectationBuilder<ChangeDescription> manualBuilder =
-			new(_expectationBuilder);
+		ManualExpectationBuilder<ChangeDescription> manualBuilder = new(_expectationBuilder);
 		expectation(new ThatSubject<ChangeDescription>(manualBuilder));
-		_filter.Add(manualBuilder, doNotPopulateThisValue);
+		_filter.Add(manualBuilder);
 		return this;
 	}
 

--- a/Source/aweXpect.Testably/Results/FileResult.Content.cs
+++ b/Source/aweXpect.Testably/Results/FileResult.Content.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemExtensions.TriggeredNotification(aweXpect.Core.IThat{MockFileSystem})" />.
+/// </summary>
+public class TriggeredNotificationResult
+	: CountResult<MockFileSystem, IThat<MockFileSystem>, TriggeredNotificationResult>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal TriggeredNotificationResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<MockFileSystem> subject,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options,
+		NotificationConstraints.TriggerNotificationFilter filter)
+		: base(expectationBuilder, subject, quantifier)
+	{
+		_expectationBuilder = expectationBuilder;
+		_options = options;
+		_filter = filter;
+	}
+
+	/// <summary>
+	///     Restricts the assertion to notifications that satisfy the inner <paramref name="expectation" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="expectation" /> is applied as an additional per-change filter, so any
+	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
+	///     <c>.HasChangeType(...)</c>) compose naturally — only notifications that satisfy all of
+	///     them count toward the quantifier.
+	/// </remarks>
+	public TriggeredNotificationResult Which(
+		Action<IThat<ChangeDescription>> expectation,
+		[CallerArgumentExpression("expectation")]
+		string doNotPopulateThisValue = "")
+	{
+		if (expectation is null)
+		{
+			throw new ArgumentNullException(nameof(expectation));
+		}
+
+		ManualExpectationBuilder<ChangeDescription> manualBuilder =
+			new(_expectationBuilder);
+		expectation(new ThatSubject<ChangeDescription>(manualBuilder));
+		_filter.Add(manualBuilder, doNotPopulateThisValue);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for waiting for asynchronous notifications.
+	/// </summary>
+	public TriggeredNotificationResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -39,22 +38,20 @@ public class TriggeredNotificationResult
 	///     The <paramref name="expectation" /> is applied as an additional per-change filter, so any
 	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
 	///     <c>.HasChangeType(...)</c>) compose naturally — only notifications that satisfy all of
-	///     them count toward the quantifier.
+	///     them count toward the quantifier. The expectation text is taken from the inner
+	///     expectation builder, so it reads like <c>matching has name equal to "foo.txt"</c> rather
+	///     than the raw lambda source.
 	/// </remarks>
-	public TriggeredNotificationResult Which(
-		Action<IThat<ChangeDescription>> expectation,
-		[CallerArgumentExpression("expectation")]
-		string doNotPopulateThisValue = "")
+	public TriggeredNotificationResult Which(Action<IThat<ChangeDescription>> expectation)
 	{
 		if (expectation is null)
 		{
 			throw new ArgumentNullException(nameof(expectation));
 		}
 
-		ManualExpectationBuilder<ChangeDescription> manualBuilder =
-			new(_expectationBuilder);
+		ManualExpectationBuilder<ChangeDescription> manualBuilder = new(_expectationBuilder);
 		expectation(new ThatSubject<ChangeDescription>(manualBuilder));
-		_filter.Add(manualBuilder, doNotPopulateThisValue);
+		_filter.Add(manualBuilder);
 		return this;
 	}
 

--- a/Source/aweXpect.Testably/aweXpect.Testably.csproj
+++ b/Source/aweXpect.Testably/aweXpect.Testably.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="aweXpect.Core"/>
-		<PackageReference Include="Testably.Abstractions.Interface"/>
+		<PackageReference Include="Testably.Abstractions.Testing"/>
 	</ItemGroup>
 
 </Project>

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -77,7 +77,7 @@ namespace aweXpect.Testably.Results
 {
     public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
     {
-        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
@@ -120,7 +120,7 @@ namespace aweXpect.Testably.Results
     }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
-        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -46,6 +59,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -54,10 +69,17 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -95,5 +117,10 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -36,6 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -44,10 +59,17 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -85,5 +107,10 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -67,7 +67,7 @@ namespace aweXpect.Testably.Results
 {
     public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
     {
-        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
@@ -110,7 +110,7 @@ namespace aweXpect.Testably.Results
     }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
-        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -67,7 +67,7 @@ namespace aweXpect.Testably.Results
 {
     public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
     {
-        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
@@ -110,7 +110,7 @@ namespace aweXpect.Testably.Results
     }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
-        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect.Testably
 {
+    public static class ChangeDescriptionExtensions
+    {
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+    }
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
@@ -36,6 +49,8 @@ namespace aweXpect.Testably
     }
     public static class FileSystemExtensions
     {
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
@@ -44,10 +59,17 @@ namespace aweXpect.Testably
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
+        public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }
 namespace aweXpect.Testably.Results
 {
+    public class DidNotTriggerNotificationResult : aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.DidNotTriggerNotificationResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
     {
@@ -85,5 +107,10 @@ namespace aweXpect.Testably.Results
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> NotSameAs(string filePath) { }
             public aweXpect.Results.StringEqualityTypeResult<TParent, aweXpect.Testably.Results.FileResult<TParent>> SameAs(string filePath) { }
         }
+    }
+    public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
+    {
+        public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation, [System.Runtime.CompilerServices.CallerArgumentExpression("expectation")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasChangeType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasChangeType.Tests.cs
@@ -23,6 +23,24 @@ public sealed partial class ChangeDescriptionTests
 			}
 
 			[Fact]
+			public async Task DoesNotHaveChangeType_WhenChangeTypeMatches_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveChangeType(WatcherChangeTypes.Created);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             does not have change type Created,
+					             but it did
+					             """);
+			}
+
+			[Fact]
 			public async Task DoesNotHaveChangeType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
 			{
 				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasChangeType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasChangeType.Tests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasChangeType
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task DoesNotHaveChangeType_WhenChangeTypeDiffers_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveChangeType(WatcherChangeTypes.Deleted);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotHaveChangeType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveChangeType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
+			public async Task WhenChangeTypeDiffers_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(WatcherChangeTypes.Deleted);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             has change type Deleted,
+					             but it was Created
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenChangeTypeMatches_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(WatcherChangeTypes.Created);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasChangeType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasFileSystemType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasFileSystemType.Tests.cs
@@ -1,0 +1,85 @@
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasFileSystemType
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task DoesNotHaveFileSystemType_WhenItDiffers_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveFileSystemType(FileSystemTypes.Directory);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotHaveFileSystemType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveFileSystemType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
+
+			[Fact]
+			public async Task WhenFileSystemTypeDiffers_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(FileSystemTypes.Directory);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             has file system type Directory,
+					             but it was File
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFileSystemTypeMatches_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasFileSystemType(FileSystemTypes.File);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasFileSystemType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasFileSystemType.Tests.cs
@@ -23,6 +23,24 @@ public sealed partial class ChangeDescriptionTests
 			}
 
 			[Fact]
+			public async Task DoesNotHaveFileSystemType_WhenItMatches_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveFileSystemType(FileSystemTypes.File);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that change
+					             does not have file system type File,
+					             but it did
+					             """);
+			}
+
+			[Fact]
 			public async Task DoesNotHaveFileSystemType_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
 			{
 				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasName.Tests.cs
@@ -1,0 +1,39 @@
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNameDiffers_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasName("bar.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has name equal to \"bar.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNameMatches_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasName(change.Name);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasNotifyFilters.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasNotifyFilters.Tests.cs
@@ -1,0 +1,97 @@
+using System.IO;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasNotifyFilters
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenFlagIsMissing_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(NotifyFilters.Security);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenFlagIsPresent_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+				NotifyFilters present = change.NotifyFilters;
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(present);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*does not have notify filters*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task DoesNotHaveNotifyFilters_WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).DoesNotHaveNotifyFilters(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+
+			[Fact]
+			public async Task WhenContainingExpectedFlag_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+				NotifyFilters expected = change.NotifyFilters;
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(expected);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
+
+			[Fact]
+			public async Task WhenMissingExpectedFlag_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasNotifyFilters(NotifyFilters.Security);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has notify filters Security*").AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasOldName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasOldName.Tests.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasOldName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenOldNameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				ChangeDescription? renamed = null;
+				using IAwaitableCallback<ChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldName("other-name.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old name equal to \"other-name.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldNameIsNull_AndExpectedIsNotNull_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasOldName("foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old name equal to \"foo.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldNameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				ChangeDescription? renamed = null;
+				using IAwaitableCallback<ChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldName(renamed!.OldName!);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasOldPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasOldPath.Tests.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasOldPath
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenOldPathDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				ChangeDescription? renamed = null;
+				using IAwaitableCallback<ChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldPath("totally-different-path");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old path equal to \"totally-different-path\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldPathIsNull_AndExpectedIsNotNull_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasOldPath("foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has old path equal to \"foo.txt\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenOldPathMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.File.WriteAllText("foo.txt", "");
+				ChangeDescription? renamed = null;
+				using IAwaitableCallback<ChangeDescription> registration =
+					fileSystem.Notify.OnEvent(c =>
+					{
+						if (c.ChangeType == WatcherChangeTypes.Renamed)
+						{
+							renamed ??= c;
+						}
+					});
+				fileSystem.File.Move("foo.txt", "bar.txt");
+
+				async Task Act()
+				{
+					await That(renamed!).HasOldPath(renamed!.OldPath!);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasPath.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.HasPath.Tests.cs
@@ -1,0 +1,39 @@
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	public sealed class HasPath
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPathDiffers_ShouldFail()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasPath("totally-different-path");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*has path equal to \"totally-different-path\"*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPathMatches_ShouldSucceed()
+			{
+				ChangeDescription change = Capture(fs => fs.File.WriteAllText("foo.txt", ""));
+
+				async Task Act()
+				{
+					await That(change).HasPath(change.Path);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.cs
@@ -1,0 +1,29 @@
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class ChangeDescriptionTests
+{
+	/// <summary>
+	///     Runs <paramref name="trigger" /> on a fresh <see cref="MockFileSystem" /> and returns
+	///     the first <see cref="ChangeDescription" /> that fired during it.
+	/// </summary>
+	/// <remarks>
+	///     Uses <see cref="IAwaitableCallback{T}.Wait(int, System.TimeSpan?)" /> so the helper does
+	///     not depend on Testably delivering notifications synchronously on the trigger thread.
+	/// </remarks>
+	internal static ChangeDescription Capture(Action<MockFileSystem> trigger)
+	{
+		MockFileSystem fileSystem = new();
+		using IAwaitableCallback<ChangeDescription> registration = fileSystem.Notify.OnEvent(_ => { });
+		trigger(fileSystem);
+		ChangeDescription[] captured = registration.Wait(1, TimeSpan.FromSeconds(5));
+		if (captured.Length == 0)
+		{
+			throw new InvalidOperationException("No notification was captured during the trigger action.");
+		}
+
+		return captured[0];
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/DirectoryInfo.WhoseParent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DirectoryInfo.WhoseParent.Tests.cs
@@ -19,7 +19,9 @@ public sealed partial class DirectoryInfo
 				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New("project/src");
 
 				async Task Act()
-					=> await That(dirInfo).WhoseParent.HasName("project");
+				{
+					await That(dirInfo).WhoseParent.HasName("project");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -33,7 +35,9 @@ public sealed partial class DirectoryInfo
 				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New("project/src");
 
 				async Task Act()
-					=> await That(dirInfo).WhoseParent.IsNotEmpty();
+				{
+					await That(dirInfo).WhoseParent.IsNotEmpty();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -45,7 +49,9 @@ public sealed partial class DirectoryInfo
 				IDirectoryInfo rootDirInfo = fileSystem.DirectoryInfo.New(fileSystem.Path.GetPathRoot(fileSystem.Directory.GetCurrentDirectory())!);
 
 				async Task Act()
-					=> await That(rootDirInfo).WhoseParent.IsNotEmpty();
+				{
+					await That(rootDirInfo).WhoseParent.IsNotEmpty();
+				}
 
 				await That(Act).Throws<InvalidOperationException>();
 			}

--- a/Tests/aweXpect.Testably.Tests/FileInfo.HasCreationTime.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.HasCreationTime.Tests.cs
@@ -34,13 +34,13 @@ public sealed partial class FileInfo
 			}
 
 			[Fact]
-			public async Task WhenCreationTimeMatches_ShouldSucceed()
+			public async Task WhenCreationTimeIsUnspecified_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();
-				DateTime expected = CurrentTime().ToUniversalTime();
+				DateTime expected = new(2020, 2, 1, 12, 0, 0, DateTimeKind.Unspecified);
 				string path = "foo.txt";
 				fileSystem.File.WriteAllText(path, "");
-				fileSystem.File.SetCreationTimeUtc(path, expected);
+				fileSystem.File.SetCreationTime(path, expected);
 				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
 
 				async Task Act()
@@ -52,13 +52,13 @@ public sealed partial class FileInfo
 			}
 
 			[Fact]
-			public async Task WhenCreationTimeIsUnspecified_ShouldSucceed()
+			public async Task WhenCreationTimeMatches_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();
-				DateTime expected = new(2020, 2, 1, 12, 0, 0, DateTimeKind.Unspecified);
+				DateTime expected = CurrentTime().ToUniversalTime();
 				string path = "foo.txt";
 				fileSystem.File.WriteAllText(path, "");
-				fileSystem.File.SetCreationTime(path, expected);
+				fileSystem.File.SetCreationTimeUtc(path, expected);
 				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
 
 				async Task Act()

--- a/Tests/aweXpect.Testably.Tests/FileInfo.WhoseParent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.WhoseParent.Tests.cs
@@ -11,20 +11,6 @@ public sealed partial class FileInfo
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task IsNotEmpty_WhenFileIsInNonEmptyDirectory_ShouldSucceed()
-			{
-				MockFileSystem fileSystem = new();
-				fileSystem.Initialize().WithSubdirectory("logs").Initialized(d => d
-					.WithFile("today.log"));
-				IFileInfo fileInfo = fileSystem.FileInfo.New("logs/today.log");
-
-				async Task Act()
-					=> await That(fileInfo).WhoseParent.IsNotEmpty();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task HasName_WhenParentNameMatches_ShouldSucceed()
 			{
 				MockFileSystem fileSystem = new();
@@ -33,7 +19,9 @@ public sealed partial class FileInfo
 				IFileInfo fileInfo = fileSystem.FileInfo.New("logs/today.log");
 
 				async Task Act()
-					=> await That(fileInfo).WhoseParent.HasName("logs");
+				{
+					await That(fileInfo).WhoseParent.HasName("logs");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -47,7 +35,25 @@ public sealed partial class FileInfo
 				IFileInfo fileInfo = fileSystem.FileInfo.New("logs/missing.log");
 
 				async Task Act()
-					=> await That(fileInfo).WhoseParent.IsNotEmpty();
+				{
+					await That(fileInfo).WhoseParent.IsNotEmpty();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IsNotEmpty_WhenFileIsInNonEmptyDirectory_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.Initialize().WithSubdirectory("logs").Initialized(d => d
+					.WithFile("today.log"));
+				IFileInfo fileInfo = fileSystem.FileInfo.New("logs/today.log");
+
+				async Task Act()
+				{
+					await That(fileInfo).WhoseParent.IsNotEmpty();
+				}
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
@@ -1,4 +1,5 @@
 using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
 
 namespace aweXpect.Testably.Tests;
 
@@ -25,6 +26,8 @@ public sealed partial class FileSystem
 			public async Task WhenPriorEventExists_ShouldFailSynchronously()
 			{
 				MockFileSystem sut = new();
+				ChangeDescription? firstEvent = null;
+				using IAwaitableCallback<ChangeDescription> reg = sut.Notify.OnEvent(c => firstEvent ??= c);
 				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
@@ -33,14 +36,21 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*did not trigger a notification*")
-					.AsWildcard();
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger a notification,
+					               but it was triggered once in [
+					                 {{firstEvent}}
+					               ]
+					               """);
 			}
 
 			[Fact]
 			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
 			{
 				MockFileSystem sut = new();
+				ChangeDescription? firstEvent = null;
+				using IAwaitableCallback<ChangeDescription> reg = sut.Notify.OnEvent(c => firstEvent ??= c);
 				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
@@ -50,8 +60,13 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*did not trigger a notification*matching*")
-					.AsWildcard();
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger a notification matching c => c.HasName("foo.txt"),
+					               but it was triggered once in [
+					                 {{firstEvent}}
+					               ]
+					               """);
 			}
 
 			[Fact]
@@ -88,6 +103,14 @@ public sealed partial class FileSystem
 			public async Task WithPredicate_WhenMatchingPriorEvent_ShouldFail()
 			{
 				MockFileSystem sut = new();
+				ChangeDescription? firstMatch = null;
+				using IAwaitableCallback<ChangeDescription> reg = sut.Notify.OnEvent(c =>
+				{
+					if (c.Name == "foo.txt")
+					{
+						firstMatch ??= c;
+					}
+				});
 				sut.File.WriteAllText("foo.txt", "x");
 
 				async Task Act()
@@ -96,8 +119,13 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*did not trigger a notification*")
-					.AsWildcard();
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger a notification matching c => c.Name == "foo.txt",
+					               but it was triggered once in [
+					                 {{firstMatch}}
+					               ]
+					               """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
@@ -1,0 +1,119 @@
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed class DidNotTriggerNotification
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNoPriorEvent_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPriorEventExists_ShouldFailSynchronously()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*did not trigger a notification*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification()
+						.Which(c => c.HasName("foo.txt"));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*did not trigger a notification*matching*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenNoMatchingChange_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification().Which(null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("expectation");
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenMatchingPriorEvent_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification(c => c.Name == "foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*did not trigger a notification*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenNoMatchingPriorEvent_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTriggerNotification(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DidNotTriggerNotification.Tests.cs
@@ -62,7 +62,7 @@ public sealed partial class FileSystem
 				await That(Act).ThrowsException()
 					.WithMessage($$"""
 					               Expected that sut
-					               did not trigger a notification matching c => c.HasName("foo.txt"),
+					               did not trigger a notification which has name equal to "foo.txt",
 					               but it was triggered once in [
 					                 {{firstEvent}}
 					               ]

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDirectory.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDirectory.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveFile.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveFile.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithDirectories.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithDirectories.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WhoseContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WhoseContent.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.EqualTo.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.EqualTo.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotEqualTo.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotSameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.NotSameAs.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.SameAs.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.SameAs.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using Testably.Abstractions.Testing;
+﻿using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;
 

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasFile.WithContent.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO.Abstractions;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Testing;
 
 namespace aweXpect.Testably.Tests;

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -31,6 +31,94 @@ public sealed partial class FileSystem
 			}
 
 			[Fact]
+			public async Task WhenLiveEventMatchesPredicate_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.Name == "foo.txt")
+						.Within(TimeSpan.FromSeconds(2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenLiveEventDoesNotMatchPredicate_ShouldFailAfterTimeout()
+			{
+				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification matching c => c.Name == "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenLiveEventMatchesWhich_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification()
+						.Which(c => c.HasName("foo.txt"))
+						.Within(TimeSpan.FromSeconds(2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenLiveEventDoesNotMatchWhich_ShouldFailAfterTimeout()
+			{
+				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification which has name equal to "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenNoPriorEvent_ShouldFailAfterTimeout()
 			{
 				MockFileSystem sut = new();
@@ -114,7 +202,7 @@ public sealed partial class FileSystem
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that sut
-					             triggered a notification matching c => c.HasName("other.txt") at least once within 0:00.100,
+					             triggered a notification which has name equal to "other.txt" at least once within 0:00.100,
 					             but it was not triggered
 					             """);
 			}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.IO;
 using aweXpect.Core;
 using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
 
 namespace aweXpect.Testably.Tests;
 
@@ -39,8 +41,11 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*triggered a notification*")
-					.AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification at least once within 0:00.100,
+					             but it was not triggered
+					             """);
 			}
 
 			[Fact]
@@ -68,8 +73,11 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*was <null>*")
-					.AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification at least once within 0:00.010,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
@@ -104,8 +112,11 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*triggered a notification*matching*")
-					.AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification matching c => c.HasName("other.txt") at least once within 0:00.100,
+					             but it was not triggered
+					             """);
 			}
 
 			[Fact]
@@ -141,6 +152,14 @@ public sealed partial class FileSystem
 			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
 			{
 				MockFileSystem sut = new();
+				List<ChangeDescription> created = new();
+				using IAwaitableCallback<ChangeDescription> reg = sut.Notify.OnEvent(c =>
+				{
+					if (c.ChangeType == WatcherChangeTypes.Created)
+					{
+						created.Add(c);
+					}
+				});
 				sut.File.WriteAllText("a.txt", "x");
 				sut.File.WriteAllText("b.txt", "x");
 
@@ -152,8 +171,14 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*triggered twice*")
-					.AsWildcard();
+					.WithMessage($$"""
+					               Expected that sut
+					               triggered a notification matching c => c.ChangeType == WatcherChangeTypes.Created exactly once within 0:00.100,
+					               but it was triggered twice in [
+					                 {{created[0]}},
+					                 {{created[1]}}
+					               ]
+					               """);
 			}
 
 			[Fact]
@@ -185,8 +210,11 @@ public sealed partial class FileSystem
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*triggered a notification*matching*")
-					.AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             triggered a notification matching c => c.Name == "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -1,0 +1,207 @@
+using System.IO;
+using aweXpect.Core;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed class TriggeredNotification
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem sut = new();
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification().Within(TimeSpan.FromSeconds(2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoPriorEvent_ShouldFailAfterTimeout()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered a notification*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MockFileSystem? sut = null;
+
+				async Task Act()
+				{
+					await That(sut!).TriggeredNotification().Within(TimeSpan.FromMilliseconds(10));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*was <null>*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_ComposesWithQuantifier()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("a.txt", "x");
+				sut.File.WriteAllText("b.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification()
+						.Which(c => c.HasChangeType(WatcherChangeTypes.Created))
+						.Exactly(2.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenChangeDoesNotMatch_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered a notification*matching*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenChangeMatches_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification()
+						.Which(c => c.HasName("foo.txt").And.HasChangeType(WatcherChangeTypes.Created));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
+			{
+				MockFileSystem sut = new();
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification().Which(null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("expectation");
+			}
+
+			[Fact]
+			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("a.txt", "x");
+				sut.File.WriteAllText("b.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered twice*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithPredicate_NarrowsAssertion()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("*triggered a notification*matching*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
+			{
+				MockFileSystem sut = new();
+				sut.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).TriggeredNotification(c => c.Name == "foo.txt");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `TriggeredNotification` / `DidNotTriggerNotification` extensions for `MockFileSystem` with quantifiers, `.Within(timeout)`, and a `.Which(c => ...)` callback that reuses `ChangeDescriptionExtensions` (`HasChangeType`, `HasFileSystemType`, `HasNotifyFilters`, `HasName`, `HasPath`, `HasOldName`, `HasOldPath`) as per-notification filters.

Bumps Testably.Abstractions.Interface to 10.2.0 and Testably.Abstractions.Testing to 6.4.0; the source library now depends on `Testably.Abstractions.Testing` since the new APIs are typed against `MockFileSystem` and `ChangeDescription`.