### PR TITLE
feat: add Triggered() / DidNotTrigger() assertions on IFileSystemWatcher

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.32.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
+		<PackageVersion Include="Testably.Abstractions" Version="10.2.0"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.2.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="6.4.0"/>
 	</ItemGroup>

--- a/README.md
+++ b/README.md
@@ -166,6 +166,52 @@ await That(fileSystem)
 > `new MockFileSystem(o => o.WithoutNotificationHistory())` only if you don't
 > use these assertions — they throw against a history-disabled file system.
 
+### Watcher events
+
+An individual `IFileSystemWatcher` can also be the subject. The watcher must
+come from a `MockFileSystem`, and `EnableRaisingEvents` must be `true` for any
+event to be observed:
+
+```csharp
+MockFileSystem fileSystem = new();
+using IFileSystemWatcher watcher = fileSystem.FileSystemWatcher.New("/");
+watcher.EnableRaisingEvents = true;
+fileSystem.File.WriteAllText("my-file.txt", "some content");
+
+await That(watcher).Triggered();
+await That(watcher).Triggered(c => c.Name == "my-file.txt");
+```
+
+Only events that originate from this specific watcher count — events fired on
+other watchers of the same `MockFileSystem` are ignored.
+
+`.Within(timeout)` (default 30 s) lets the assertion wait for asynchronous
+events:
+
+```csharp
+_ = Task.Run(() => fileSystem.File.WriteAllText("foo.txt", "x"));
+await That(watcher).Triggered().Within(100.Milliseconds());
+```
+
+`DidNotTrigger` mirrors the same shapes and short-circuits as soon as a
+matching event is observed:
+
+```csharp
+await That(watcher).DidNotTrigger().Within(100.Milliseconds());
+await That(watcher).DidNotTrigger(c => c.Name == "secret.txt");
+```
+
+Both `Triggered` and `DidNotTrigger` accept either a synchronous
+`Func<WatcherChangeDescription, bool>` predicate or a `.Which(c => …)` callback
+that composes inner expectations from `ChangeDescriptionExtensions`:
+
+```csharp
+await That(watcher)
+    .Triggered()
+    .Which(c => c.HasName("my-file.txt").And.HasChangeType(WatcherChangeTypes.Created))
+    .Exactly(1.Times());
+```
+
 ### `ChangeDescription` as a subject
 
 Individual `ChangeDescription` instances can be asserted directly. The

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasChangeType.cs
@@ -20,9 +20,10 @@ public static partial class ChangeDescriptionExtensions
 	/// <remarks>
 	///     The check uses flag containment, because <see cref="WatcherChangeTypes" /> is a flag enum.
 	/// </remarks>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasChangeType(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> HasChangeType<TChange>(
+		this IThat<TChange> source,
 		WatcherChangeTypes expected)
+		where TChange : ChangeDescription
 	{
 		if (expected == default)
 		{
@@ -30,9 +31,9 @@ public static partial class ChangeDescriptionExtensions
 				"The expected change type must include at least one flag.", nameof(expected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, expected)),
+				=> new NotificationConstraints.HasChangeTypeConstraint<TChange>(it, grammars, expected)),
 			source);
 	}
 
@@ -40,9 +41,10 @@ public static partial class ChangeDescriptionExtensions
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
 	///     <see cref="WatcherChangeTypes" />.
 	/// </summary>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveChangeType(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> DoesNotHaveChangeType<TChange>(
+		this IThat<TChange> source,
 		WatcherChangeTypes unexpected)
+		where TChange : ChangeDescription
 	{
 		if (unexpected == default)
 		{
@@ -50,9 +52,9 @@ public static partial class ChangeDescriptionExtensions
 				"The unexpected change type must include at least one flag.", nameof(unexpected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasChangeTypeConstraint(it, grammars, unexpected).Invert()),
+				=> new NotificationConstraints.HasChangeTypeConstraint<TChange>(it, grammars, unexpected).Invert()),
 			source);
 	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasFileSystemType.cs
@@ -17,9 +17,10 @@ public static partial class ChangeDescriptionExtensions
 	/// <remarks>
 	///     The check uses flag containment, because <see cref="FileSystemTypes" /> is a flag enum.
 	/// </remarks>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasFileSystemType(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> HasFileSystemType<TChange>(
+		this IThat<TChange> source,
 		FileSystemTypes expected)
+		where TChange : ChangeDescription
 	{
 		if (expected == default)
 		{
@@ -27,9 +28,9 @@ public static partial class ChangeDescriptionExtensions
 				"The expected file system type must include at least one flag.", nameof(expected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, expected)),
+				=> new NotificationConstraints.HasFileSystemTypeConstraint<TChange>(it, grammars, expected)),
 			source);
 	}
 
@@ -37,9 +38,10 @@ public static partial class ChangeDescriptionExtensions
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
 	///     <see cref="FileSystemTypes" />.
 	/// </summary>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveFileSystemType(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> DoesNotHaveFileSystemType<TChange>(
+		this IThat<TChange> source,
 		FileSystemTypes unexpected)
+		where TChange : ChangeDescription
 	{
 		if (unexpected == default)
 		{
@@ -47,9 +49,9 @@ public static partial class ChangeDescriptionExtensions
 				"The unexpected file system type must include at least one flag.", nameof(unexpected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasFileSystemTypeConstraint(it, grammars, unexpected).Invert()),
+				=> new NotificationConstraints.HasFileSystemTypeConstraint<TChange>(it, grammars, unexpected).Invert()),
 			source);
 	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasName.cs
@@ -15,14 +15,15 @@ public static partial class ChangeDescriptionExtensions
 	///     <see cref="ChangeDescription.Name" /> can be <see langword="null" /> on the underlying
 	///     <see cref="ChangeDescription" />, so <paramref name="expected" /> is nullable too.
 	/// </remarks>
-	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasName(
-		this IThat<ChangeDescription> source,
+	public static StringEqualityTypeResult<TChange, IThat<TChange>> HasName<TChange>(
+		this IThat<TChange> source,
 		string? expected)
+		where TChange : ChangeDescription
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new StringEqualityTypeResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasStringPropertyConstraint(
+				=> new NotificationConstraints.HasStringPropertyConstraint<TChange>(
 					it, grammars, c => c.Name, options, expected, "name")),
 			source,
 			options);

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasNotifyFilters.cs
@@ -17,9 +17,10 @@ public static partial class ChangeDescriptionExtensions
 	/// <remarks>
 	///     The check uses flag containment, because <see cref="NotifyFilters" /> is a flag enum.
 	/// </remarks>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> HasNotifyFilters(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> HasNotifyFilters<TChange>(
+		this IThat<TChange> source,
 		NotifyFilters expected)
+		where TChange : ChangeDescription
 	{
 		if (expected == default)
 		{
@@ -27,9 +28,9 @@ public static partial class ChangeDescriptionExtensions
 				"The expected notify filters must include at least one flag.", nameof(expected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, expected)),
+				=> new NotificationConstraints.HasNotifyFiltersConstraint<TChange>(it, grammars, expected)),
 			source);
 	}
 
@@ -37,9 +38,10 @@ public static partial class ChangeDescriptionExtensions
 	///     Verifies that the <see cref="ChangeDescription" /> does not have the <paramref name="unexpected" />
 	///     <see cref="NotifyFilters" />.
 	/// </summary>
-	public static AndOrResult<ChangeDescription, IThat<ChangeDescription>> DoesNotHaveNotifyFilters(
-		this IThat<ChangeDescription> source,
+	public static AndOrResult<TChange, IThat<TChange>> DoesNotHaveNotifyFilters<TChange>(
+		this IThat<TChange> source,
 		NotifyFilters unexpected)
+		where TChange : ChangeDescription
 	{
 		if (unexpected == default)
 		{
@@ -47,9 +49,9 @@ public static partial class ChangeDescriptionExtensions
 				"The unexpected notify filters must include at least one flag.", nameof(unexpected));
 		}
 
-		return new AndOrResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new AndOrResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasNotifyFiltersConstraint(it, grammars, unexpected).Invert()),
+				=> new NotificationConstraints.HasNotifyFiltersConstraint<TChange>(it, grammars, unexpected).Invert()),
 			source);
 	}
 }

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldName.cs
@@ -15,14 +15,15 @@ public static partial class ChangeDescriptionExtensions
 	///     The old name is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change,
 	///     so <see cref="ChangeDescription.OldName" /> is nullable and <paramref name="expected" /> is too.
 	/// </remarks>
-	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldName(
-		this IThat<ChangeDescription> source,
+	public static StringEqualityTypeResult<TChange, IThat<TChange>> HasOldName<TChange>(
+		this IThat<TChange> source,
 		string? expected)
+		where TChange : ChangeDescription
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new StringEqualityTypeResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasStringPropertyConstraint(
+				=> new NotificationConstraints.HasStringPropertyConstraint<TChange>(
 					it, grammars, c => c.OldName, options, expected, "old name")),
 			source,
 			options);

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasOldPath.cs
@@ -15,14 +15,15 @@ public static partial class ChangeDescriptionExtensions
 	///     The old path is only set on a <see cref="System.IO.WatcherChangeTypes.Renamed" /> change,
 	///     so <see cref="ChangeDescription.OldPath" /> is nullable and <paramref name="expected" /> is too.
 	/// </remarks>
-	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasOldPath(
-		this IThat<ChangeDescription> source,
+	public static StringEqualityTypeResult<TChange, IThat<TChange>> HasOldPath<TChange>(
+		this IThat<TChange> source,
 		string? expected)
+		where TChange : ChangeDescription
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new StringEqualityTypeResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasStringPropertyConstraint(
+				=> new NotificationConstraints.HasStringPropertyConstraint<TChange>(
 					it, grammars, c => c.OldPath, options, expected, "old path")),
 			source,
 			options);

--- a/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
+++ b/Source/aweXpect.Testably/ChangeDescriptionExtensions.HasPath.cs
@@ -15,14 +15,15 @@ public static partial class ChangeDescriptionExtensions
 	///     <see cref="ChangeDescription.Path" /> is always set on the underlying
 	///     <see cref="ChangeDescription" />, so <paramref name="expected" /> is non-nullable.
 	/// </remarks>
-	public static StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>> HasPath(
-		this IThat<ChangeDescription> source,
+	public static StringEqualityTypeResult<TChange, IThat<TChange>> HasPath<TChange>(
+		this IThat<TChange> source,
 		string expected)
+		where TChange : ChangeDescription
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<ChangeDescription, IThat<ChangeDescription>>(
+		return new StringEqualityTypeResult<TChange, IThat<TChange>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.HasStringPropertyConstraint(
+				=> new NotificationConstraints.HasStringPropertyConstraint<TChange>(
 					it, grammars, c => c.Path, options, expected, "path")),
 			source,
 			options);

--- a/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.TriggeredNotification.cs
@@ -89,7 +89,7 @@ public static partial class FileSystemExtensions
 	{
 		Quantifier quantifier = new();
 		NotificationTimeoutOptions options = new();
-		NotificationConstraints.TriggerNotificationFilter filter = new();
+		NotificationConstraints.TriggerNotificationFilter<ChangeDescription> filter = new();
 		if (predicate is not null)
 		{
 			filter.Add(predicate, predicateExpression);
@@ -98,8 +98,12 @@ public static partial class FileSystemExtensions
 		List<ChangeDescription> matches = new();
 		return new TriggeredNotificationResult(
 			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.TriggeredNotificationConstraint(
-					it, grammars, filter, quantifier, options, matches)),
+				=> new NotificationConstraints.TriggeredNotificationConstraint<MockFileSystem, ChangeDescription>(
+					it, grammars,
+					"triggered a notification",
+					"did not trigger a notification",
+					(fs, action, f) => fs.Notify.OnEventOrReplay(action, f),
+					filter, quantifier, options, matches)),
 			subject,
 			quantifier,
 			options,
@@ -113,7 +117,7 @@ public static partial class FileSystemExtensions
 	{
 		Quantifier quantifier = new();
 		NotificationTimeoutOptions options = new();
-		NotificationConstraints.TriggerNotificationFilter filter = new();
+		NotificationConstraints.TriggerNotificationFilter<ChangeDescription> filter = new();
 		if (predicate is not null)
 		{
 			filter.Add(predicate, predicateExpression);
@@ -122,8 +126,12 @@ public static partial class FileSystemExtensions
 		List<ChangeDescription> matches = new();
 		return new DidNotTriggerNotificationResult(
 			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new NotificationConstraints.TriggeredNotificationConstraint(
-					it, grammars, filter, quantifier, options, matches,
+				=> new NotificationConstraints.TriggeredNotificationConstraint<MockFileSystem, ChangeDescription>(
+					it, grammars,
+					"triggered a notification",
+					"did not trigger a notification",
+					(fs, action, f) => fs.Notify.OnEventOrReplay(action, f),
+					filter, quantifier, options, matches,
 					true).Invert()),
 			subject,
 			options,

--- a/Source/aweXpect.Testably/FileSystemWatcherExtensions.Triggered.cs
+++ b/Source/aweXpect.Testably/FileSystemWatcherExtensions.Triggered.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Testably.Helpers;
+using aweXpect.Testably.Results;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="IFileSystemWatcher" />.
+/// </summary>
+public static class FileSystemWatcherExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystemWatcher" /> triggered an event.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" />, so events
+	///     that already fired on this watcher count toward the quantifier. The assertion always
+	///     waits up to a timeout for late-arriving (asynchronous) events — 30 seconds by default;
+	///     use <c>.Within(timeout)</c> to override.
+	///     The subject must be created from a <see cref="MockFileSystem" /> — calling this on a
+	///     real-file-system watcher throws <see cref="InvalidOperationException" />. The watcher's
+	///     <see cref="IFileSystemWatcher.EnableRaisingEvents" /> must be <see langword="true" /> for
+	///     any event to be observed.
+	/// </remarks>
+	public static TriggeredWatcherResult Triggered(
+		this IThat<IFileSystemWatcher> subject)
+		=> TriggeredCore(subject, null, "");
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystemWatcher" /> triggered an event for a change
+	///     matching the <paramref name="predicate" />.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" />, so events
+	///     that already fired on this watcher count toward the quantifier. The assertion always
+	///     waits up to a timeout for late-arriving (asynchronous) events — 30 seconds by default;
+	///     use <c>.Within(timeout)</c> to override.
+	///     The subject must be created from a <see cref="MockFileSystem" /> — calling this on a
+	///     real-file-system watcher throws <see cref="InvalidOperationException" />. The watcher's
+	///     <see cref="IFileSystemWatcher.EnableRaisingEvents" /> must be <see langword="true" /> for
+	///     any event to be observed.
+	/// </remarks>
+	public static TriggeredWatcherResult Triggered(
+		this IThat<IFileSystemWatcher> subject,
+		Func<WatcherChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		if (predicate is null)
+		{
+			throw new ArgumentNullException(nameof(predicate));
+		}
+
+		return TriggeredCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystemWatcher" /> did <i>not</i> trigger an event.
+	/// </summary>
+	/// <remarks>
+	///     Subscribes via <see cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" /> so any event
+	///     that already fired on this watcher fails the assertion. The assertion also waits up to a
+	///     timeout for late-arriving events — 30 seconds by default; use <c>.Within(timeout)</c>
+	///     to lower it when you do not need to wait. The assertion short-circuits as soon as a
+	///     matching event is observed.
+	///     The subject must be created from a <see cref="MockFileSystem" /> — calling this on a
+	///     real-file-system watcher throws <see cref="InvalidOperationException" />. The watcher's
+	///     <see cref="IFileSystemWatcher.EnableRaisingEvents" /> must be <see langword="true" /> for
+	///     any event to be observed.
+	/// </remarks>
+	public static DidNotTriggerWatcherResult DidNotTrigger(
+		this IThat<IFileSystemWatcher> subject)
+		=> DidNotTriggerCore(subject, null, "");
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystemWatcher" /> did <i>not</i> trigger an event for
+	///     any change matching the <paramref name="predicate" />.
+	/// </summary>
+	public static DidNotTriggerWatcherResult DidNotTrigger(
+		this IThat<IFileSystemWatcher> subject,
+		Func<WatcherChangeDescription, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		if (predicate is null)
+		{
+			throw new ArgumentNullException(nameof(predicate));
+		}
+
+		return DidNotTriggerCore(subject, predicate, doNotPopulateThisValue);
+	}
+
+	private static TriggeredWatcherResult TriggeredCore(
+		IThat<IFileSystemWatcher> subject,
+		Func<WatcherChangeDescription, bool>? predicate,
+		string predicateExpression)
+	{
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
+		List<WatcherChangeDescription> matches = new();
+		return new TriggeredWatcherResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint<IFileSystemWatcher, WatcherChangeDescription>(
+					it, grammars,
+					"triggered an event",
+					"did not trigger an event",
+					Subscribe,
+					filter, quantifier, options, matches)),
+			subject,
+			quantifier,
+			options,
+			filter);
+	}
+
+	private static DidNotTriggerWatcherResult DidNotTriggerCore(
+		IThat<IFileSystemWatcher> subject,
+		Func<WatcherChangeDescription, bool>? predicate,
+		string predicateExpression)
+	{
+		Quantifier quantifier = new();
+		NotificationTimeoutOptions options = new();
+		NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> filter = new();
+		if (predicate is not null)
+		{
+			filter.Add(predicate, predicateExpression);
+		}
+
+		List<WatcherChangeDescription> matches = new();
+		return new DidNotTriggerWatcherResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new NotificationConstraints.TriggeredNotificationConstraint<IFileSystemWatcher, WatcherChangeDescription>(
+					it, grammars,
+					"triggered an event",
+					"did not trigger an event",
+					Subscribe,
+					filter, quantifier, options, matches,
+					true).Invert()),
+			subject,
+			options,
+			filter);
+	}
+
+	private static IAwaitableCallback<WatcherChangeDescription> Subscribe(
+		IFileSystemWatcher watcher,
+		Action<WatcherChangeDescription> action,
+		Func<WatcherChangeDescription, bool> userFilter)
+	{
+		if (watcher.FileSystem is not MockFileSystem mockFs)
+		{
+			throw new InvalidOperationException(
+				"Triggered() and DidNotTrigger() require an IFileSystemWatcher created from a MockFileSystem.");
+		}
+
+		return mockFs.Watcher.OnTriggeredOrReplay(
+			action,
+			c => c.FileSystemWatcher == watcher && userFilter(c));
+	}
+}

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -55,7 +55,8 @@ internal static class NotificationConstraints
 				actual,
 				change =>
 				{
-					if (!filter.IsAsyncMatchSync(change, context, cancellationToken))
+					if (deadlineToken.IsCancellationRequested ||
+					    !filter.IsAsyncMatchSync(change, context, deadlineToken))
 					{
 						return;
 					}

--- a/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/NotificationConstraints.cs
@@ -16,18 +16,23 @@ namespace aweXpect.Testably.Helpers;
 
 internal static class NotificationConstraints
 {
-	internal sealed class TriggeredNotificationConstraint(
+	internal sealed class TriggeredNotificationConstraint<TSubject, TChange>(
 		string it,
 		ExpectationGrammars grammars,
-		TriggerNotificationFilter filter,
+		string normalExpectation,
+		string negatedExpectation,
+		Func<TSubject, Action<TChange>, Func<TChange, bool>, IAwaitableCallback<TChange>> subscribe,
+		TriggerNotificationFilter<TChange> filter,
 		Quantifier quantifier,
 		NotificationTimeoutOptions options,
-		List<ChangeDescription> matches,
+		List<TChange> matches,
 		bool exitOnFirstMatch = false)
-		: ConstraintResult.WithValue<MockFileSystem>(grammars),
-			IAsyncContextConstraint<MockFileSystem>
+		: ConstraintResult.WithValue<TSubject>(grammars),
+			IAsyncContextConstraint<TSubject>
+		where TSubject : class
+		where TChange : ChangeDescription
 	{
-		public async Task<ConstraintResult> IsMetBy(MockFileSystem actual,
+		public async Task<ConstraintResult> IsMetBy(TSubject actual,
 			IEvaluationContext context,
 			CancellationToken cancellationToken)
 		{
@@ -46,7 +51,8 @@ internal static class NotificationConstraints
 			deadlineCts.CancelAfter(timeout);
 			CancellationToken deadlineToken = deadlineCts.Token;
 
-			using IAwaitableCallback<ChangeDescription> registration = actual.Notify.OnEventOrReplay(
+			using IAwaitableCallback<TChange> registration = subscribe(
+				actual,
 				change =>
 				{
 					if (!filter.IsAsyncMatchSync(change, context, cancellationToken))
@@ -91,7 +97,7 @@ internal static class NotificationConstraints
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append("triggered a notification");
+			stringBuilder.Append(normalExpectation);
 			stringBuilder.Append(filter);
 			stringBuilder.Append(' ').Append(quantifier);
 			stringBuilder.Append(options);
@@ -102,7 +108,7 @@ internal static class NotificationConstraints
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append("did not trigger a notification");
+			stringBuilder.Append(negatedExpectation);
 			stringBuilder.Append(filter);
 			stringBuilder.Append(options);
 		}
@@ -118,7 +124,7 @@ internal static class NotificationConstraints
 				return;
 			}
 
-			ChangeDescription[] snapshot;
+			TChange[] snapshot;
 			lock (matches)
 			{
 				snapshot = matches.ToArray();
@@ -164,12 +170,13 @@ internal static class NotificationConstraints
 		}
 	}
 
-	internal sealed class TriggerNotificationFilter
+	internal sealed class TriggerNotificationFilter<TChange>
+		where TChange : ChangeDescription
 	{
-		private readonly List<ManualExpectationBuilder<ChangeDescription>> _asyncFilters = new();
-		private readonly List<(Func<ChangeDescription, bool> Predicate, string Description)> _syncPredicates = new();
+		private readonly List<ManualExpectationBuilder<TChange>> _asyncFilters = new();
+		private readonly List<(Func<TChange, bool> Predicate, string Description)> _syncPredicates = new();
 
-		public void Add(Func<ChangeDescription, bool> predicate, string predicateExpression)
+		public void Add(Func<TChange, bool> predicate, string predicateExpression)
 		{
 			if (predicate is null)
 			{
@@ -179,17 +186,17 @@ internal static class NotificationConstraints
 			_syncPredicates.Add((predicate, predicateExpression.Trim()));
 		}
 
-		public void Add(ManualExpectationBuilder<ChangeDescription> builder)
+		public void Add(ManualExpectationBuilder<TChange> builder)
 			=> _asyncFilters.Add(builder);
 
-		public bool IsSyncMatch(ChangeDescription change)
+		public bool IsSyncMatch(TChange change)
 			=> _syncPredicates.All(p => p.Predicate(change));
 
-		public bool IsAsyncMatchSync(ChangeDescription change,
+		public bool IsAsyncMatchSync(TChange change,
 			IEvaluationContext context,
 			CancellationToken cancellationToken)
 		{
-			foreach (ManualExpectationBuilder<ChangeDescription> builder in _asyncFilters)
+			foreach (ManualExpectationBuilder<TChange> builder in _asyncFilters)
 			{
 				ConstraintResult result = builder.IsMetBy(change, context, cancellationToken)
 					.ConfigureAwait(false).GetAwaiter().GetResult();
@@ -211,17 +218,17 @@ internal static class NotificationConstraints
 
 			StringBuilder sb = new();
 			bool firstInGroup = true;
-			foreach ((Func<ChangeDescription, bool> _, string description) in _syncPredicates)
+			foreach ((Func<TChange, bool> _, string description) in _syncPredicates)
 			{
 				sb.Append(firstInGroup ? " matching " : " and ").Append(description);
 				firstInGroup = false;
 			}
 
 			firstInGroup = true;
-			foreach (ManualExpectationBuilder<ChangeDescription> builder in _asyncFilters)
+			foreach (ManualExpectationBuilder<TChange> builder in _asyncFilters)
 			{
 				sb.Append(firstInGroup ? " which " : " and ");
-				builder.AppendExpectation(sb, indentation: "");
+				builder.AppendExpectation(sb, "");
 				firstInGroup = false;
 			}
 
@@ -229,14 +236,15 @@ internal static class NotificationConstraints
 		}
 	}
 
-	internal sealed class HasChangeTypeConstraint(
+	internal sealed class HasChangeTypeConstraint<TChange>(
 		string it,
 		ExpectationGrammars grammars,
 		WatcherChangeTypes expected)
-		: ConstraintResult.WithValue<ChangeDescription>(grammars),
-			IValueConstraint<ChangeDescription>
+		: ConstraintResult.WithValue<TChange>(grammars),
+			IValueConstraint<TChange>
+		where TChange : ChangeDescription
 	{
-		public ConstraintResult IsMetBy(ChangeDescription actual)
+		public ConstraintResult IsMetBy(TChange actual)
 		{
 			Actual = actual;
 			Outcome = actual != null! && (actual.ChangeType & expected) == expected
@@ -276,14 +284,15 @@ internal static class NotificationConstraints
 		}
 	}
 
-	internal sealed class HasFileSystemTypeConstraint(
+	internal sealed class HasFileSystemTypeConstraint<TChange>(
 		string it,
 		ExpectationGrammars grammars,
 		FileSystemTypes expected)
-		: ConstraintResult.WithValue<ChangeDescription>(grammars),
-			IValueConstraint<ChangeDescription>
+		: ConstraintResult.WithValue<TChange>(grammars),
+			IValueConstraint<TChange>
+		where TChange : ChangeDescription
 	{
-		public ConstraintResult IsMetBy(ChangeDescription actual)
+		public ConstraintResult IsMetBy(TChange actual)
 		{
 			Actual = actual;
 			Outcome = actual != null! && (actual.FileSystemType & expected) == expected
@@ -323,14 +332,15 @@ internal static class NotificationConstraints
 		}
 	}
 
-	internal sealed class HasNotifyFiltersConstraint(
+	internal sealed class HasNotifyFiltersConstraint<TChange>(
 		string it,
 		ExpectationGrammars grammars,
 		NotifyFilters expected)
-		: ConstraintResult.WithValue<ChangeDescription>(grammars),
-			IValueConstraint<ChangeDescription>
+		: ConstraintResult.WithValue<TChange>(grammars),
+			IValueConstraint<TChange>
+		where TChange : ChangeDescription
 	{
-		public ConstraintResult IsMetBy(ChangeDescription actual)
+		public ConstraintResult IsMetBy(TChange actual)
 		{
 			Actual = actual;
 			Outcome = actual != null! && (actual.NotifyFilters & expected) == expected
@@ -370,19 +380,20 @@ internal static class NotificationConstraints
 		}
 	}
 
-	internal sealed class HasStringPropertyConstraint(
+	internal sealed class HasStringPropertyConstraint<TChange>(
 		string it,
 		ExpectationGrammars grammars,
-		Func<ChangeDescription, string?> selector,
+		Func<TChange, string?> selector,
 		StringEqualityOptions options,
 		string? expected,
 		string propertyName)
-		: ConstraintResult.WithValue<ChangeDescription>(grammars),
-			IAsyncConstraint<ChangeDescription>
+		: ConstraintResult.WithValue<TChange>(grammars),
+			IAsyncConstraint<TChange>
+		where TChange : ChangeDescription
 	{
 		private string? _actualValue;
 
-		public async Task<ConstraintResult> IsMetBy(ChangeDescription actual,
+		public async Task<ConstraintResult> IsMetBy(TChange actual,
 			CancellationToken cancellationToken)
 		{
 			Actual = actual;

--- a/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerNotificationResult.cs
@@ -14,14 +14,13 @@ public class DidNotTriggerNotificationResult
 	: AndOrResult<MockFileSystem, IThat<MockFileSystem>, DidNotTriggerNotificationResult>
 {
 	private readonly ExpectationBuilder _expectationBuilder;
-	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationConstraints.TriggerNotificationFilter<ChangeDescription> _filter;
 	private readonly NotificationTimeoutOptions _options;
 
 	internal DidNotTriggerNotificationResult(
 		ExpectationBuilder expectationBuilder,
 		IThat<MockFileSystem> subject,
-		NotificationTimeoutOptions options,
-		NotificationConstraints.TriggerNotificationFilter filter)
+		NotificationTimeoutOptions options, NotificationConstraints.TriggerNotificationFilter<ChangeDescription> filter)
 		: base(expectationBuilder, subject)
 	{
 		_expectationBuilder = expectationBuilder;

--- a/Source/aweXpect.Testably/Results/DidNotTriggerWatcherResult.cs
+++ b/Source/aweXpect.Testably/Results/DidNotTriggerWatcherResult.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemWatcherExtensions.DidNotTrigger(aweXpect.Core.IThat{IFileSystemWatcher})" />.
+/// </summary>
+public class DidNotTriggerWatcherResult
+	: AndOrResult<IFileSystemWatcher, IThat<IFileSystemWatcher>, DidNotTriggerWatcherResult>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal DidNotTriggerWatcherResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<IFileSystemWatcher> subject,
+		NotificationTimeoutOptions options, NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> filter)
+		: base(expectationBuilder, subject)
+	{
+		_expectationBuilder = expectationBuilder;
+		_options = options;
+		_filter = filter;
+	}
+
+	/// <summary>
+	///     Restricts the assertion to events that satisfy the inner <paramref name="expectation" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="expectation" /> is applied as an additional per-event filter, so any
+	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
+	///     <c>.HasChangeType(...)</c>) compose naturally — the assertion fails if any event
+	///     satisfies all of them. The expectation text is taken from the inner expectation builder,
+	///     so it reads like <c>which has name equal to "foo.txt"</c> rather than the raw lambda
+	///     source.
+	/// </remarks>
+	public DidNotTriggerWatcherResult Which(Action<IThat<WatcherChangeDescription>> expectation)
+	{
+		if (expectation is null)
+		{
+			throw new ArgumentNullException(nameof(expectation));
+		}
+
+		ManualExpectationBuilder<WatcherChangeDescription> manualBuilder = new(_expectationBuilder);
+		expectation(new ThatSubject<WatcherChangeDescription>(manualBuilder));
+		_filter.Add(manualBuilder);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for waiting for asynchronous events.
+	/// </summary>
+	public DidNotTriggerWatcherResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredNotificationResult.cs
@@ -15,15 +15,14 @@ public class TriggeredNotificationResult
 	: CountResult<MockFileSystem, IThat<MockFileSystem>, TriggeredNotificationResult>
 {
 	private readonly ExpectationBuilder _expectationBuilder;
-	private readonly NotificationConstraints.TriggerNotificationFilter _filter;
+	private readonly NotificationConstraints.TriggerNotificationFilter<ChangeDescription> _filter;
 	private readonly NotificationTimeoutOptions _options;
 
 	internal TriggeredNotificationResult(
 		ExpectationBuilder expectationBuilder,
 		IThat<MockFileSystem> subject,
 		Quantifier quantifier,
-		NotificationTimeoutOptions options,
-		NotificationConstraints.TriggerNotificationFilter filter)
+		NotificationTimeoutOptions options, NotificationConstraints.TriggerNotificationFilter<ChangeDescription> filter)
 		: base(expectationBuilder, subject, quantifier)
 	{
 		_expectationBuilder = expectationBuilder;

--- a/Source/aweXpect.Testably/Results/TriggeredWatcherResult.cs
+++ b/Source/aweXpect.Testably/Results/TriggeredWatcherResult.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="FileSystemWatcherExtensions.Triggered(aweXpect.Core.IThat{IFileSystemWatcher})" />.
+/// </summary>
+public class TriggeredWatcherResult
+	: CountResult<IFileSystemWatcher, IThat<IFileSystemWatcher>, TriggeredWatcherResult>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> _filter;
+	private readonly NotificationTimeoutOptions _options;
+
+	internal TriggeredWatcherResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<IFileSystemWatcher> subject,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options, NotificationConstraints.TriggerNotificationFilter<WatcherChangeDescription> filter)
+		: base(expectationBuilder, subject, quantifier)
+	{
+		_expectationBuilder = expectationBuilder;
+		_options = options;
+		_filter = filter;
+	}
+
+	/// <summary>
+	///     Restricts the assertion to events that satisfy the inner <paramref name="expectation" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="expectation" /> is applied as an additional per-event filter, so any
+	///     assertions from <see cref="ChangeDescriptionExtensions" /> (e.g. <c>.HasName(...)</c>,
+	///     <c>.HasChangeType(...)</c>) compose naturally — only events that satisfy all of them
+	///     count toward the quantifier. The expectation text is taken from the inner expectation
+	///     builder, so it reads like <c>which has name equal to "foo.txt"</c> rather than the raw
+	///     lambda source.
+	/// </remarks>
+	public TriggeredWatcherResult Which(Action<IThat<WatcherChangeDescription>> expectation)
+	{
+		if (expectation is null)
+		{
+			throw new ArgumentNullException(nameof(expectation));
+		}
+
+		ManualExpectationBuilder<WatcherChangeDescription> manualBuilder = new(_expectationBuilder);
+		expectation(new ThatSubject<WatcherChangeDescription>(manualBuilder));
+		_filter.Add(manualBuilder);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for waiting for asynchronous events.
+	/// </summary>
+	public TriggeredWatcherResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -4,16 +4,26 @@ namespace aweXpect.Testably
 {
     public static class ChangeDescriptionExtensions
     {
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldPath<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasPath<TChange>(this aweXpect.Core.IThat<TChange> source, string expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
     }
     public static class DirectoryInfoExtensions
     {
@@ -72,6 +82,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileSystemWatcherExtensions
+    {
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+    }
 }
 namespace aweXpect.Testably.Results
 {
@@ -79,6 +96,11 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class DidNotTriggerWatcherResult : aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.DidNotTriggerWatcherResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
@@ -122,5 +144,10 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class TriggeredWatcherResult : aweXpect.Results.CountResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.TriggeredWatcherResult>
+    {
+        public aweXpect.Testably.Results.TriggeredWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.TriggeredWatcherResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -4,16 +4,26 @@ namespace aweXpect.Testably
 {
     public static class ChangeDescriptionExtensions
     {
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldPath<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasPath<TChange>(this aweXpect.Core.IThat<TChange> source, string expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
     }
     public static class DirectoryInfoExtensions
     {
@@ -62,6 +72,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileSystemWatcherExtensions
+    {
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+    }
 }
 namespace aweXpect.Testably.Results
 {
@@ -69,6 +86,11 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class DidNotTriggerWatcherResult : aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.DidNotTriggerWatcherResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
@@ -112,5 +134,10 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class TriggeredWatcherResult : aweXpect.Results.CountResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.TriggeredWatcherResult>
+    {
+        public aweXpect.Testably.Results.TriggeredWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.TriggeredWatcherResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -4,16 +4,26 @@ namespace aweXpect.Testably
 {
     public static class ChangeDescriptionExtensions
     {
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> DoesNotHaveNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters unexpected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasChangeType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.WatcherChangeTypes expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasFileSystemType(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, Testably.Abstractions.Testing.FileSystemTypes expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.AndOrResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasNotifyFilters(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, System.IO.NotifyFilters expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldName(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasOldPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string? expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<Testably.Abstractions.Testing.FileSystem.ChangeDescription, aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> HasPath(this aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> DoesNotHaveNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters unexpected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasChangeType<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.WatcherChangeTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasFileSystemType<TChange>(this aweXpect.Core.IThat<TChange> source, Testably.Abstractions.Testing.FileSystemTypes expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.AndOrResult<TChange, aweXpect.Core.IThat<TChange>> HasNotifyFilters<TChange>(this aweXpect.Core.IThat<TChange> source, System.IO.NotifyFilters expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldName<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasOldPath<TChange>(this aweXpect.Core.IThat<TChange> source, string? expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
+        public static aweXpect.Results.StringEqualityTypeResult<TChange, aweXpect.Core.IThat<TChange>> HasPath<TChange>(this aweXpect.Core.IThat<TChange> source, string expected)
+            where TChange : Testably.Abstractions.Testing.FileSystem.ChangeDescription { }
     }
     public static class DirectoryInfoExtensions
     {
@@ -62,6 +72,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject) { }
         public static aweXpect.Testably.Results.TriggeredNotificationResult TriggeredNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileSystemWatcherExtensions
+    {
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.DidNotTriggerWatcherResult DidNotTrigger(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
+        public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+    }
 }
 namespace aweXpect.Testably.Results
 {
@@ -69,6 +86,11 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.DidNotTriggerNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class DidNotTriggerWatcherResult : aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.DidNotTriggerWatcherResult>
+    {
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.DidNotTriggerWatcherResult Within(System.TimeSpan timeout) { }
     }
     public class DirectoryResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
         where TParent :  class
@@ -112,5 +134,10 @@ namespace aweXpect.Testably.Results
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }
         public aweXpect.Testably.Results.TriggeredNotificationResult Within(System.TimeSpan timeout) { }
+    }
+    public class TriggeredWatcherResult : aweXpect.Results.CountResult<System.IO.Abstractions.IFileSystemWatcher, aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher>, aweXpect.Testably.Results.TriggeredWatcherResult>
+    {
+        public aweXpect.Testably.Results.TriggeredWatcherResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>> expectation) { }
+        public aweXpect.Testably.Results.TriggeredWatcherResult Within(System.TimeSpan timeout) { }
     }
 }

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
@@ -34,6 +34,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventFired_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -61,6 +62,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 
@@ -76,6 +78,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -104,6 +107,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenNoMatchingChange_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -122,6 +126,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 
@@ -138,6 +143,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenMatchingEvent_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -165,6 +171,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenNoMatchingEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
@@ -1,0 +1,182 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystemWatcher
+{
+	public sealed class DidNotTrigger
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAnotherWatcherFires_ShouldStillSucceed()
+			{
+				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/a");
+				fs.Directory.CreateDirectory("/b");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/a");
+				using IFileSystemWatcher other = fs.FileSystemWatcher.New("/b");
+				sut.EnableRaisingEvents = true;
+				other.EnableRaisingEvents = true;
+				fs.File.WriteAllText("/b/foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventFired_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
+					_ => { },
+					c => c.FileSystemWatcher == sut);
+				fs.File.WriteAllText("foo.txt", "x");
+				WatcherChangeDescription firstEvent = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger an event,
+					               but it was triggered once in [
+					                 {{firstEvent}}
+					               ]
+					               """);
+			}
+
+			[Fact]
+			public async Task WhenNoEvent_ShouldSucceed()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
+					_ => { },
+					c => c.FileSystemWatcher == sut && c.Name == "foo.txt");
+				fs.File.WriteAllText("foo.txt", "x");
+				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger()
+						.Which(c => c.HasName("foo.txt"));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger an event which has name equal to "foo.txt",
+					               but it was triggered once in [
+					                 {{firstMatch}}
+					               ]
+					               """);
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenNoMatchingChange_ShouldSucceed()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger().Which(null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("expectation");
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenMatchingEvent_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
+					_ => { },
+					c => c.FileSystemWatcher == sut && c.Name == "foo.txt");
+				fs.File.WriteAllText("foo.txt", "x");
+				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger(c => c.Name == "foo.txt");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($$"""
+					               Expected that sut
+					               did not trigger an event matching c => c.Name == "foo.txt",
+					               but it was triggered once in [
+					                 {{firstMatch}}
+					               ]
+					               """);
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenNoMatchingEvent_ShouldSucceed()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).DidNotTrigger(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
@@ -1,0 +1,389 @@
+using System.IO;
+using System.IO.Abstractions;
+using aweXpect.Core;
+using Testably.Abstractions;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystemWatcher
+{
+	public sealed class Triggered
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAnotherWatcherFires_ShouldNotCountTowardThisWatcher()
+			{
+				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/a");
+				fs.Directory.CreateDirectory("/b");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/a");
+				using IFileSystemWatcher other = fs.FileSystemWatcher.New("/b");
+				sut.EnableRaisingEvents = true;
+				other.EnableRaisingEvents = true;
+				fs.File.WriteAllText("/b/foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					fs.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).Triggered().Within(TimeSpan.FromSeconds(10));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenLiveEventDoesNotMatchPredicate_ShouldFailAfterTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					fs.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event matching c => c.Name == "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenLiveEventDoesNotMatchWhich_ShouldFailAfterTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					fs.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).Triggered()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event which has name equal to "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenLiveEventMatchesPredicate_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					fs.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.Name == "foo.txt")
+						.Within(TimeSpan.FromSeconds(2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenLiveEventMatchesWhich_ShouldSucceedWithinTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					fs.File.WriteAllText("foo.txt", "x");
+				});
+
+				async Task Act()
+				{
+					await That(sut).Triggered()
+						.Which(c => c.HasName("foo.txt"))
+						.Within(TimeSpan.FromSeconds(2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoEvent_ShouldFailAfterTimeout()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+
+				async Task Act()
+				{
+					await That(sut).Triggered().Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotFromMockFileSystem_ShouldThrowInvalidOperationException()
+			{
+				RealFileSystem realFs = new();
+				using IFileSystemWatcher sut = realFs.FileSystemWatcher.New(Path.GetTempPath());
+
+				async Task Act()
+				{
+					await That(sut).Triggered().Within(TimeSpan.FromMilliseconds(10));
+				}
+
+				await That(Act).Throws<InvalidOperationException>();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IFileSystemWatcher? sut = null;
+
+				async Task Act()
+				{
+					await That(sut!).Triggered().Within(TimeSpan.FromMilliseconds(10));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event at least once within 0:00.010,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_ComposesWithQuantifier()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("a.txt", "x");
+				fs.File.WriteAllText("b.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered()
+						.Which(c => c.HasChangeType(WatcherChangeTypes.Created))
+						.Exactly(2.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenChangeDoesNotMatch_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered()
+						.Which(c => c.HasName("other.txt"))
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event which has name equal to "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WhichWithInnerExpectation_WhenChangeMatches_ShouldSucceed()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered()
+						.Which(c => c.HasName("foo.txt").And.HasChangeType(WatcherChangeTypes.Created));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+
+				async Task Act()
+				{
+					await That(sut).Triggered().Which(null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("expectation");
+			}
+
+			[Fact]
+			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
+					_ => { },
+					c => c.FileSystemWatcher == sut && c.ChangeType == WatcherChangeTypes.Created);
+				fs.File.WriteAllText("a.txt", "x");
+				fs.File.WriteAllText("b.txt", "x");
+				WatcherChangeDescription[] created = reg.Wait(2, TimeSpan.FromSeconds(5));
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($$"""
+					               Expected that sut
+					               triggered an event matching c => c.ChangeType == WatcherChangeTypes.Created exactly once within 0:00.100,
+					               but it was triggered twice in [
+					                 {{created[0]}},
+					                 {{created[1]}}
+					               ]
+					               """);
+			}
+
+			[Fact]
+			public async Task WithPredicate_NarrowsAssertion()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.ChangeType == WatcherChangeTypes.Created)
+						.Exactly(1.Times())
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.Name == "other.txt")
+						.Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             triggered an event matching c => c.Name == "other.txt" at least once within 0:00.100,
+					             but it was not triggered
+					             """);
+			}
+
+			[Fact]
+			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
+			{
+				MockFileSystem fs = new();
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				sut.EnableRaisingEvents = true;
+				fs.File.WriteAllText("foo.txt", "x");
+
+				async Task Act()
+				{
+					await That(sut).Triggered(c => c.Name == "foo.txt");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
@@ -42,6 +42,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -62,6 +63,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchPredicate_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -88,6 +90,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchWhich_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -115,6 +118,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesPredicate_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -136,6 +140,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesWhich_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -158,6 +163,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 
@@ -178,6 +184,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -226,6 +233,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_ComposesWithQuantifier()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("a.txt", "x");
@@ -246,6 +254,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -269,6 +278,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -286,6 +296,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 
@@ -302,6 +313,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -333,6 +345,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_NarrowsAssertion()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -351,6 +364,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -373,6 +387,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
+				fs.Directory.CreateDirectory("/");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");

--- a/Tests/aweXpect.Testably.Tests/aweXpect.Testably.Tests.csproj
+++ b/Tests/aweXpect.Testably.Tests/aweXpect.Testably.Tests.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="aweXpect"/>
+		<PackageReference Include="Testably.Abstractions"/>
 		<PackageReference Include="Testably.Abstractions.Testing"/>
 	</ItemGroup>
 


### PR DESCRIPTION
Adds Triggered() / DidNotTrigger() shape on IThat<IFileSystemWatcher>, subscribing to MockFileSystem.Watcher with an implicit per-watcher filter. ChangeDescriptionExtensions and the underlying notification constraint are generalized over TChange : ChangeDescription so the same HasName / HasChangeType / etc. assertions compose on WatcherChangeDescription via .Which(...).

Real-file-system watchers throw InvalidOperationException to keep the assertion's contract explicit. Default .Within timeout is 30 s, matching the notification side.