### PR TITLE
fix: increase timeout and fix file system watcher paths for brittle tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.cs
+++ b/Tests/aweXpect.Testably.Tests/ChangeDescriptionTests.cs
@@ -18,7 +18,7 @@ public sealed partial class ChangeDescriptionTests
 		MockFileSystem fileSystem = new();
 		using IAwaitableCallback<ChangeDescription> registration = fileSystem.Notify.OnEvent(_ => { });
 		trigger(fileSystem);
-		ChangeDescription[] captured = registration.Wait(1, TimeSpan.FromSeconds(5));
+		ChangeDescription[] captured = registration.Wait(1, TimeSpan.FromSeconds(30));
 		if (captured.Length == 0)
 		{
 			throw new InvalidOperationException("No notification was captured during the trigger action.");

--- a/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.TriggeredNotification.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class FileSystem
 
 				async Task Act()
 				{
-					await That(sut).TriggeredNotification().Within(TimeSpan.FromSeconds(2));
+					await That(sut).TriggeredNotification().Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -43,7 +43,7 @@ public sealed partial class FileSystem
 				async Task Act()
 				{
 					await That(sut).TriggeredNotification(c => c.Name == "foo.txt")
-						.Within(TimeSpan.FromSeconds(2));
+						.Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -87,7 +87,7 @@ public sealed partial class FileSystem
 				{
 					await That(sut).TriggeredNotification()
 						.Which(c => c.HasName("foo.txt"))
-						.Within(TimeSpan.FromSeconds(2));
+						.Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
@@ -34,8 +34,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventFired_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -63,8 +62,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
@@ -80,8 +78,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -110,8 +107,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenNoMatchingChange_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -130,8 +126,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
@@ -148,8 +143,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenMatchingEvent_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -177,8 +171,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenNoMatchingEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
@@ -34,8 +34,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventFired_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
 					_ => { },
@@ -62,8 +63,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
 				async Task Act()
@@ -78,8 +80,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenMatchingChange_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
 					_ => { },
@@ -107,8 +110,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenNoMatchingChange_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -126,8 +130,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
 				async Task Act()
@@ -143,8 +148,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenMatchingEvent_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
 					_ => { },
@@ -171,8 +177,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenNoMatchingEvent_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.DidNotTrigger.Tests.cs
@@ -41,7 +41,7 @@ public sealed partial class FileSystemWatcher
 					_ => { },
 					c => c.FileSystemWatcher == sut);
 				fs.File.WriteAllText("foo.txt", "x");
-				WatcherChangeDescription firstEvent = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+				WatcherChangeDescription firstEvent = reg.Wait(1, TimeSpan.FromSeconds(30))[0];
 
 				async Task Act()
 				{
@@ -85,7 +85,7 @@ public sealed partial class FileSystemWatcher
 					_ => { },
 					c => c.FileSystemWatcher == sut && c.Name == "foo.txt");
 				fs.File.WriteAllText("foo.txt", "x");
-				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(30))[0];
 
 				async Task Act()
 				{
@@ -150,7 +150,7 @@ public sealed partial class FileSystemWatcher
 					_ => { },
 					c => c.FileSystemWatcher == sut && c.Name == "foo.txt");
 				fs.File.WriteAllText("foo.txt", "x");
-				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(5))[0];
+				WatcherChangeDescription firstMatch = reg.Wait(1, TimeSpan.FromSeconds(30))[0];
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
@@ -42,8 +42,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -64,8 +63,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchPredicate_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -92,8 +90,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchWhich_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -121,8 +118,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesPredicate_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -144,8 +140,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesWhich_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
@@ -168,8 +163,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
@@ -190,8 +184,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -240,8 +233,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_ComposesWithQuantifier()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("a.txt", "x");
@@ -262,8 +254,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -287,8 +278,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -306,8 +296,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
@@ -324,8 +313,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
@@ -357,8 +345,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_NarrowsAssertion()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -377,8 +364,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
@@ -401,8 +387,7 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/x");
-				fs.Directory.SetCurrentDirectory("/x");
+				fs.InitializeIn("/x");
 				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
@@ -42,8 +42,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenEventArrivesAsynchronously_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
 				{
@@ -63,8 +64,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchPredicate_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
 				{
@@ -90,8 +92,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventDoesNotMatchWhich_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
 				{
@@ -118,8 +121,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesPredicate_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
 				{
@@ -140,8 +144,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenLiveEventMatchesWhich_ShouldSucceedWithinTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				_ = Task.Run(async () =>
 				{
@@ -163,8 +168,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenNoEvent_ShouldFailAfterTimeout()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
 				async Task Act()
@@ -184,8 +190,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhenPriorEventExists_ShouldSucceedSynchronously()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -233,8 +240,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_ComposesWithQuantifier()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("a.txt", "x");
 				fs.File.WriteAllText("b.txt", "x");
@@ -254,8 +262,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -278,8 +287,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithInnerExpectation_WhenChangeMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -296,8 +306,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WhichWithNullExpectation_ShouldThrowArgumentNullException()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 
 				async Task Act()
@@ -313,8 +324,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithExactlyOnce_WhenTriggeredTwice_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				using IAwaitableCallback<WatcherChangeDescription> reg = fs.Watcher.OnTriggered(
 					_ => { },
@@ -345,8 +357,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_NarrowsAssertion()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -364,8 +377,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventDoesNotMatch_ShouldFail()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 
@@ -387,8 +401,9 @@ public sealed partial class FileSystemWatcher
 			public async Task WithPredicate_WhenPriorEventMatches_ShouldSucceed()
 			{
 				MockFileSystem fs = new();
-				fs.Directory.CreateDirectory("/");
-				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/");
+				fs.Directory.CreateDirectory("/x");
+				fs.Directory.SetCurrentDirectory("/x");
+				using IFileSystemWatcher sut = fs.FileSystemWatcher.New("/x");
 				sut.EnableRaisingEvents = true;
 				fs.File.WriteAllText("foo.txt", "x");
 

--- a/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystemWatcher.Triggered.Tests.cs
@@ -53,7 +53,7 @@ public sealed partial class FileSystemWatcher
 
 				async Task Act()
 				{
-					await That(sut).Triggered().Within(TimeSpan.FromSeconds(10));
+					await That(sut).Triggered().Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -130,7 +130,7 @@ public sealed partial class FileSystemWatcher
 				async Task Act()
 				{
 					await That(sut).Triggered(c => c.Name == "foo.txt")
-						.Within(TimeSpan.FromSeconds(2));
+						.Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -153,7 +153,7 @@ public sealed partial class FileSystemWatcher
 				{
 					await That(sut).Triggered()
 						.Which(c => c.HasName("foo.txt"))
-						.Within(TimeSpan.FromSeconds(2));
+						.Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -321,7 +321,7 @@ public sealed partial class FileSystemWatcher
 					c => c.FileSystemWatcher == sut && c.ChangeType == WatcherChangeTypes.Created);
 				fs.File.WriteAllText("a.txt", "x");
 				fs.File.WriteAllText("b.txt", "x");
-				WatcherChangeDescription[] created = reg.Wait(2, TimeSpan.FromSeconds(5));
+				WatcherChangeDescription[] created = reg.Wait(2, TimeSpan.FromSeconds(30));
 
 				async Task Act()
 				{


### PR DESCRIPTION
This pull request makes two main types of improvements: it increases the timeouts for many test assertions to reduce test flakiness, and it standardizes test setup for file system watcher tests by initializing the mock file system in a subdirectory (`/x`) instead of the root. Additionally, it updates the GitHub Actions workflow matrix strategies to prevent early job termination when one matrix job fails.

**Test reliability improvements:**

* Increased timeouts in multiple test assertions from 2–10 seconds to 30 seconds to reduce the likelihood of flaky test failures due to slow event propagation or CI performance variability.

**Test setup standardization:**

* Changed test setup in file system watcher tests to use `fs.InitializeIn("/x")` and watch `/x` instead of creating and watching the root directory. This was applied consistently across all relevant tests for improved isolation and reliability.

**CI workflow improvements:**

* Set `fail-fast: false` in the matrix strategy for both `build.yml` and `ci.yml` GitHub Actions workflows, ensuring that all jobs in the matrix run to completion even if one fails.