### PR TITLE
chore: update aweXpect package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.32.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.29.0"/>
+		<PackageVersion Include="aweXpect" Version="2.34.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.31.1"/>
 		<PackageVersion Include="Testably.Abstractions" Version="10.2.0"/>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.2.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="6.4.0"/>

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithFiles.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithFiles.Tests.cs
@@ -32,9 +32,17 @@ public sealed partial class FileSystem
 						              has directory '{path}' whose files have content equal to "SOME-CONTENT" for all items,
 						              but not all were
 
-						              File content:
-						              some-content
-						              """);
+						              Not matching items:
+						              [
+						                foo\bar.txt,
+						                (… and maybe others)
+						              ]
+
+						              Collection:
+						              [
+						                foo\bar.txt
+						              ]
+						              """).IgnoringNewlineStyle();
 				}
 
 				[Fact]
@@ -93,9 +101,17 @@ public sealed partial class FileSystem
 						              has directory '{path}' whose files have content not equal to "some-content" for all items,
 						              but not all were
 
-						              File content:
-						              some-content
-						              """);
+						              Not matching items:
+						              [
+						                foo\bar.txt,
+						                (… and maybe others)
+						              ]
+
+						              Collection:
+						              [
+						                foo\bar.txt
+						              ]
+						              """).IgnoringNewlineStyle();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithFiles.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDirectory.WithFiles.Tests.cs
@@ -34,13 +34,13 @@ public sealed partial class FileSystem
 
 						              Not matching items:
 						              [
-						                foo\bar.txt,
+						                foo{Path.DirectorySeparatorChar}bar.txt,
 						                (… and maybe others)
 						              ]
 
 						              Collection:
 						              [
-						                foo\bar.txt
+						                foo{Path.DirectorySeparatorChar}bar.txt
 						              ]
 						              """).IgnoringNewlineStyle();
 				}
@@ -103,13 +103,13 @@ public sealed partial class FileSystem
 
 						              Not matching items:
 						              [
-						                foo\bar.txt,
+						                foo{Path.DirectorySeparatorChar}bar.txt,
 						                (… and maybe others)
 						              ]
 
 						              Collection:
 						              [
-						                foo\bar.txt
+						                foo{Path.DirectorySeparatorChar}bar.txt
 						              ]
 						              """).IgnoringNewlineStyle();
 				}


### PR DESCRIPTION
This PR updates the centrally-managed `aweXpect` / `aweXpect.Core` NuGet package versions and adjusts existing tests to match updated assertion failure message formatting introduced by the newer aweXpect versions.

**Changes:**
- Bump `aweXpect` to `2.34.0` and `aweXpect.Core` to `2.31.1` via central package management.
- Update failure-message assertions in `FileSystem.HasDirectory.WithFiles` tests to the new “Not matching items / Collection” message structure and ignore newline style differences.