### PR TITLE
feat: add drive info expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,42 @@ fileSystem.File.WriteAllText("foo/bar/my-file.txt", "some content");
 await That(fileSystem).HasDirectory("foo/bar").WithFiles(f => f.All().ComplyWith(x => x.HasContent("SOME CONTENT").IgnoringCase()));
 ```
 
+### Drives
+
+You can verify that a drive is registered on the file system. Drives are
+matched by name (case-insensitive) against `IFileSystem.DriveInfo.GetDrives()`;
+UNC drives (which do not appear in `GetDrives()`) are not supported by
+`HasDrive`:
+
+```csharp
+MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+
+await That(fileSystem).HasDrive("D:\\");
+await That(fileSystem).DoesNotHaveDrive("Z:\\");
+```
+
+`HasDrive` exposes a `.Which` property returning `IThat<IDriveInfo>`, so all
+`IDriveInfo` assertions can be chained directly:
+
+```csharp
+await That(fileSystem).HasDrive("D:\\")
+    .Which.HasTotalSize(2048).And.IsReady();
+```
+
+You can also assert directly on `IDriveInfo` instances:
+
+```csharp
+IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+await That(driveInfo).HasAvailableFreeSpace(2048);
+await That(driveInfo).HasTotalSize(2048).And.HasTotalFreeSpace(2048);
+await That(driveInfo).HasDriveFormat("NTFS");
+await That(driveInfo).HasDriveType(System.IO.DriveType.Fixed);
+await That(driveInfo).HasName(driveInfo.Name).And.HasVolumeLabel(driveInfo.VolumeLabel);
+await That(driveInfo).IsReady();
+```
+
 ### IFileInfo / IDirectoryInfo as subjects
 
 You can also assert directly on `IFileInfo` and `IDirectoryInfo` instances:
@@ -97,13 +133,14 @@ await That(dirInfo).HasDirectory("bar").Which.HasFile("my-file.txt");
 
 ### Bridging from the file-system chain via `.Which`
 
-`HasFile` and `HasDirectory` expose a `.Which` property that returns the
-`IThat<IFileInfo>` / `IThat<IDirectoryInfo>` for the resolved entry, so the
-same assertions light up in both places:
+`HasFile`, `HasDirectory` and `HasDrive` expose a `.Which` property that returns
+the `IThat<IFileInfo>` / `IThat<IDirectoryInfo>` / `IThat<IDriveInfo>` for the
+resolved entry, so the same assertions light up in both places:
 
 ```csharp
 await That(fileSystem).HasFile("my-file.txt").Which.HasLength(12).And.HasContent("some content");
 await That(fileSystem).HasDirectory("logs").Which.IsEmpty();
+await That(fileSystem).HasDrive("D:\\").Which.IsReady().And.HasDriveFormat("NTFS");
 ```
 
 ### IFileVersionInfo

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasAvailableFreeSpace.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasAvailableFreeSpace.cs
@@ -1,0 +1,72 @@
+using System.IO.Abstractions;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> available free space in bytes.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> HasAvailableFreeSpace(this IThat<IDriveInfo> source,
+		long expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasAvailableFreeSpaceConstraint(it, grammars, expected)),
+			source);
+
+	private sealed class HasAvailableFreeSpaceConstraint(string it, ExpectationGrammars grammars, long expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IValueConstraint<IDriveInfo>
+	{
+		private long _actualAvailableFreeSpace;
+
+		public ConstraintResult IsMetBy(IDriveInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualAvailableFreeSpace = actual.AvailableFreeSpace;
+			Outcome = _actualAvailableFreeSpace == expected ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has available free space ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(_actualAvailableFreeSpace);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have available free space ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasDriveFormat.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasDriveFormat.cs
@@ -1,0 +1,83 @@
+using System.IO.Abstractions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> drive format.
+	/// </summary>
+	public static StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>> HasDriveFormat(this IThat<IDriveInfo> source,
+		string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasDriveFormatConstraint(it, grammars, options, expected)),
+			source,
+			options);
+	}
+
+	private sealed class HasDriveFormatConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		StringEqualityOptions options,
+		string expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IAsyncConstraint<IDriveInfo>
+	{
+		private string? _actualDriveFormat;
+
+		public async Task<ConstraintResult> IsMetBy(IDriveInfo actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualDriveFormat = actual.DriveFormat;
+			Outcome = await options.AreConsideredEqual(_actualDriveFormat, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has drive format ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualDriveFormat, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have drive format ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasDriveType.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasDriveType.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using System.IO.Abstractions;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> <see cref="DriveType" />.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> HasDriveType(this IThat<IDriveInfo> source,
+		DriveType expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasDriveTypeConstraint(it, grammars, expected)),
+			source);
+
+	private sealed class HasDriveTypeConstraint(string it, ExpectationGrammars grammars, DriveType expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IValueConstraint<IDriveInfo>
+	{
+		private DriveType _actualDriveType;
+
+		public ConstraintResult IsMetBy(IDriveInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualDriveType = actual.DriveType;
+			Outcome = _actualDriveType == expected ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has drive type ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(_actualDriveType);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have drive type ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasName.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasName.cs
@@ -1,0 +1,83 @@
+using System.IO.Abstractions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>> HasName(this IThat<IDriveInfo> source,
+		string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, options, expected)),
+			source,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		StringEqualityOptions options,
+		string expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IAsyncConstraint<IDriveInfo>
+	{
+		private string? _actualName;
+
+		public async Task<ConstraintResult> IsMetBy(IDriveInfo actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualName = actual.Name;
+			Outcome = await options.AreConsideredEqual(_actualName, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualName, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasTotalFreeSpace.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasTotalFreeSpace.cs
@@ -1,0 +1,72 @@
+using System.IO.Abstractions;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> total free space in bytes.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> HasTotalFreeSpace(this IThat<IDriveInfo> source,
+		long expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasTotalFreeSpaceConstraint(it, grammars, expected)),
+			source);
+
+	private sealed class HasTotalFreeSpaceConstraint(string it, ExpectationGrammars grammars, long expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IValueConstraint<IDriveInfo>
+	{
+		private long _actualTotalFreeSpace;
+
+		public ConstraintResult IsMetBy(IDriveInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualTotalFreeSpace = actual.TotalFreeSpace;
+			Outcome = _actualTotalFreeSpace == expected ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has total free space ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(_actualTotalFreeSpace);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have total free space ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasTotalSize.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasTotalSize.cs
@@ -1,0 +1,72 @@
+using System.IO.Abstractions;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> total size in bytes.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> HasTotalSize(this IThat<IDriveInfo> source,
+		long expected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasTotalSizeConstraint(it, grammars, expected)),
+			source);
+
+	private sealed class HasTotalSizeConstraint(string it, ExpectationGrammars grammars, long expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IValueConstraint<IDriveInfo>
+	{
+		private long _actualTotalSize;
+
+		public ConstraintResult IsMetBy(IDriveInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualTotalSize = actual.TotalSize;
+			Outcome = _actualTotalSize == expected ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has total size ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(_actualTotalSize);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have total size ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.HasVolumeLabel.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.HasVolumeLabel.cs
@@ -1,0 +1,83 @@
+using System.IO.Abstractions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> has the <paramref name="expected" /> volume label.
+	/// </summary>
+	public static StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>> HasVolumeLabel(this IThat<IDriveInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IDriveInfo, IThat<IDriveInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasVolumeLabelConstraint(it, grammars, options, expected)),
+			source,
+			options);
+	}
+
+	private sealed class HasVolumeLabelConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		StringEqualityOptions options,
+		string? expected)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IAsyncConstraint<IDriveInfo>
+	{
+		private string? _actualVolumeLabel;
+
+		public async Task<ConstraintResult> IsMetBy(IDriveInfo actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualVolumeLabel = actual.VolumeLabel;
+			Outcome = await options.AreConsideredEqual(_actualVolumeLabel, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has volume label ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualVolumeLabel, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have volume label ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.IsReady.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.IsReady.cs
@@ -1,0 +1,77 @@
+using System.IO.Abstractions;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DriveInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> is ready.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> IsReady(this IThat<IDriveInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsReadyConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="IDriveInfo" /> is not ready.
+	/// </summary>
+	public static AndOrResult<IDriveInfo, IThat<IDriveInfo>> IsNotReady(this IThat<IDriveInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsReadyConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class IsReadyConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<IDriveInfo>(grammars),
+			IValueConstraint<IDriveInfo>
+	{
+		public ConstraintResult IsMetBy(IDriveInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			Outcome = actual.IsReady ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is ready");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was not");
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not ready");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was");
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/DriveInfoExtensions.cs
+++ b/Source/aweXpect.Testably/DriveInfoExtensions.cs
@@ -1,0 +1,10 @@
+using System.IO.Abstractions;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="IDriveInfo" />.
+/// </summary>
+public static partial class DriveInfoExtensions
+{
+}

--- a/Source/aweXpect.Testably/FileSystemExtensions.HasDrive.cs
+++ b/Source/aweXpect.Testably/FileSystemExtensions.HasDrive.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using aweXpect.Testably.Results;
+
+namespace aweXpect.Testably;
+
+public static partial class FileSystemExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystem" /> has a drive with the given <paramref name="driveName" />.
+	/// </summary>
+	/// <remarks>
+	///     The drive is resolved by case-insensitive name match against
+	///     <see cref="IDriveInfoFactory.GetDrives" />. UNC drives (which do not appear in
+	///     <c>GetDrives()</c>) are not supported by this assertion.
+	/// </remarks>
+	public static DriveResult<TFileSystem> HasDrive<TFileSystem>(
+		this IThat<TFileSystem> subject, string driveName)
+		where TFileSystem : class, IFileSystem
+	{
+		Func<TFileSystem, IDriveInfo?> resolver = fs => ResolveDrive(fs, driveName);
+		return new DriveResult<TFileSystem>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasDriveConstraint<TFileSystem>(it, grammars, driveName, resolver)),
+			subject,
+			resolver);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileSystem" /> does not have a drive with the given <paramref name="driveName" />.
+	/// </summary>
+	/// <remarks>
+	///     The drive is resolved by case-insensitive name match against
+	///     <see cref="IDriveInfoFactory.GetDrives" />. UNC drives (which do not appear in
+	///     <c>GetDrives()</c>) are not supported by this assertion.
+	/// </remarks>
+	public static AndOrResult<TFileSystem, IThat<TFileSystem>> DoesNotHaveDrive<TFileSystem>(
+		this IThat<TFileSystem> subject, string driveName)
+		where TFileSystem : class, IFileSystem
+	{
+		Func<TFileSystem, IDriveInfo?> resolver = fs => ResolveDrive(fs, driveName);
+		return new AndOrResult<TFileSystem, IThat<TFileSystem>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasDriveConstraint<TFileSystem>(it, grammars, driveName, resolver).Invert()),
+			subject);
+	}
+
+	private static IDriveInfo? ResolveDrive(IFileSystem fileSystem, string driveName)
+	{
+		string normalized = NormalizeDriveName(driveName);
+		return fileSystem.DriveInfo.GetDrives()
+			.FirstOrDefault(d => string.Equals(
+				NormalizeDriveName(d.Name), normalized, StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static string NormalizeDriveName(string name)
+		=> name.TrimEnd('\\', '/');
+
+	private sealed class HasDriveConstraint<TFileSystem>(
+		string it,
+		ExpectationGrammars grammars,
+		string driveName,
+		Func<TFileSystem, IDriveInfo?> resolver)
+		: ConstraintResult.WithValue<TFileSystem>(grammars),
+			IValueConstraint<TFileSystem>
+		where TFileSystem : class, IFileSystem
+	{
+		public ConstraintResult IsMetBy(TFileSystem actual)
+		{
+			Actual = actual;
+			Outcome = resolver(actual) is not null ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has drive '").Append(driveName).Append('\'');
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(it).Append(" did not exist");
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have drive '").Append(driveName).Append('\'');
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(it).Append(" did");
+	}
+}

--- a/Source/aweXpect.Testably/Results/DriveResult.cs
+++ b/Source/aweXpect.Testably/Results/DriveResult.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Results;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for additional verifications on a drive.
+/// </summary>
+public class DriveResult<TParent>
+	: AndOrResult<TParent, IThat<TParent>>
+	where TParent : class
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly Func<TParent, IDriveInfo?> _resolver;
+
+	internal DriveResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<TParent> subject,
+		Func<TParent, IDriveInfo?> resolver)
+		: base(expectationBuilder, subject)
+	{
+		_expectationBuilder = expectationBuilder;
+		_resolver = resolver;
+	}
+
+	/// <summary>
+	///     Further expectations on the <see cref="IDriveInfo" /> identified by this drive result.
+	/// </summary>
+	public IThat<IDriveInfo> Which
+		=> new ThatSubject<IDriveInfo>(
+			_expectationBuilder.ForWhich<TParent, IDriveInfo>(
+				_resolver, " which "));
+}

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -47,6 +47,18 @@ namespace aweXpect.Testably
             public aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> WhoseParent { get; }
         }
     }
+    public static class DriveInfoExtensions
+    {
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasAvailableFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveFormat(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveType(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, System.IO.DriveType expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasName(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalSize(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasVolumeLabel(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsNotReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+    }
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
@@ -76,9 +88,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.DirectoryResult<TFileSystem> HasDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.DriveResult<TFileSystem> HasDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
@@ -457,6 +473,11 @@ namespace aweXpect.Testably.Results
         public aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> Which { get; }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithDirectories(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IDirectoryInfo>>> expectations) { }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithFiles(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IFileInfo>>> expectations) { }
+    }
+    public class DriveResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
+        where TParent :  class
+    {
+        public aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> Which { get; }
     }
     public class FileInfoContentResult
     {

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -42,6 +42,18 @@ namespace aweXpect.Testably
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> IsEmpty(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> IsNotEmpty(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
     }
+    public static class DriveInfoExtensions
+    {
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasAvailableFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveFormat(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveType(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, System.IO.DriveType expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasName(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalSize(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasVolumeLabel(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsNotReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+    }
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
@@ -66,9 +78,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.DirectoryResult<TFileSystem> HasDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.DriveResult<TFileSystem> HasDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
@@ -447,6 +463,11 @@ namespace aweXpect.Testably.Results
         public aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> Which { get; }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithDirectories(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IDirectoryInfo>>> expectations) { }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithFiles(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IFileInfo>>> expectations) { }
+    }
+    public class DriveResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
+        where TParent :  class
+    {
+        public aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> Which { get; }
     }
     public class FileInfoContentResult
     {

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -42,6 +42,18 @@ namespace aweXpect.Testably
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> IsEmpty(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> IsNotEmpty(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
     }
+    public static class DriveInfoExtensions
+    {
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasAvailableFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveFormat(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasDriveType(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, System.IO.DriveType expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasName(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalFreeSpace(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasTotalSize(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, long expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> HasVolumeLabel(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsNotReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDriveInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo>> IsReady(this aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> source) { }
+    }
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
@@ -66,9 +78,13 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.DidNotTriggerNotificationResult DidNotTriggerNotification(this aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem> subject, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Results.AndOrResult<TFileSystem, aweXpect.Core.IThat<TFileSystem>> DoesNotHaveFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.DirectoryResult<TFileSystem> HasDirectory<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
+            where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
+        public static aweXpect.Testably.Results.DriveResult<TFileSystem> HasDrive<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string driveName)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
         public static aweXpect.Testably.Results.FileResult<TFileSystem> HasFile<TFileSystem>(this aweXpect.Core.IThat<TFileSystem> subject, string path)
             where TFileSystem :  class, System.IO.Abstractions.IFileSystem { }
@@ -445,6 +461,11 @@ namespace aweXpect.Testably.Results
         public aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> Which { get; }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithDirectories(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IDirectoryInfo>>> expectations) { }
         public aweXpect.Testably.Results.DirectoryResult<TParent> WithFiles(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.IO.Abstractions.IFileInfo>>> expectations) { }
+    }
+    public class DriveResult<TParent> : aweXpect.Results.AndOrResult<TParent, aweXpect.Core.IThat<TParent>>
+        where TParent :  class
+    {
+        public aweXpect.Core.IThat<System.IO.Abstractions.IDriveInfo> Which { get; }
     }
     public class FileInfoContentResult
     {

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasAvailableFreeSpace.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasAvailableFreeSpace.Tests.cs
@@ -1,0 +1,65 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasAvailableFreeSpace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAvailableFreeSpaceMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasAvailableFreeSpace(2048);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAvailableFreeSpaceDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasAvailableFreeSpace(99);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             has available free space 99,
+					             but it was 2048
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasAvailableFreeSpace(99));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasDriveFormat.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasDriveFormat.Tests.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasDriveFormat
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveFormatMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveFormat("NTFS"));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasDriveFormat("NTFS");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveFormatDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveFormat("NTFS"));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasDriveFormat("FAT32");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             has drive format equal to "FAT32",
+					             but it was "NTFS" which differs at index 0:
+					                ↓ (actual)
+					               "NTFS"
+					               "FAT32"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveFormat("NTFS"));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasDriveFormat("FAT32"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasDriveType.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasDriveType.Tests.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasDriveType
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveTypeMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveType(DriveType.Fixed));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasDriveType(DriveType.Fixed);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveTypeDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveType(DriveType.Fixed));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasDriveType(DriveType.Network);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             has drive type Network,
+					             but it was Fixed
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetDriveType(DriveType.Fixed));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasDriveType(DriveType.Network));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasName.Tests.cs
@@ -1,0 +1,61 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:");
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasName(driveInfo.Name);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:");
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasName("Z:\\");
+				}
+
+				await That(Act).ThrowsException();
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:");
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasName("Z:\\"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasTotalFreeSpace.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasTotalFreeSpace.Tests.cs
@@ -1,0 +1,66 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasTotalFreeSpace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTotalFreeSpaceMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasTotalFreeSpace(2048);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTotalFreeSpaceDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasTotalFreeSpace(99);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             has total free space 99,
+					             but it was 2048
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasTotalFreeSpace(99));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasTotalSize.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasTotalSize.Tests.cs
@@ -1,0 +1,66 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasTotalSize
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTotalSizeMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasTotalSize(2048);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTotalSizeDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasTotalSize(99);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             has total size 99,
+					             but it was 2048
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetTotalSize(2048));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasTotalSize(99));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.HasVolumeLabel.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.HasVolumeLabel.Tests.cs
@@ -1,0 +1,59 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class HasVolumeLabel
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenVolumeLabelMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("C:");
+				string actualLabel = driveInfo.VolumeLabel;
+
+				async Task Act()
+				{
+					await That(driveInfo).HasVolumeLabel(actualLabel);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenVolumeLabelDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("C:");
+
+				async Task Act()
+				{
+					await That(driveInfo).HasVolumeLabel("definitely-not-the-label");
+				}
+
+				await That(Act).ThrowsException();
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedIfDiffers()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("C:");
+
+				async Task Act()
+				{
+					await That(driveInfo).DoesNotComplyWith(d => d.HasVolumeLabel("definitely-not-the-label"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.IsNotReady.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.IsNotReady.Tests.cs
@@ -1,0 +1,51 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class IsNotReady
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveIsNotReady_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetIsReady(false));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).IsNotReady();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveIsReady_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetIsReady(true));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).IsNotReady();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             is not ready,
+					             but it was
+					             """);
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.IsReady.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.IsReady.Tests.cs
@@ -1,0 +1,51 @@
+#if NET8_0_OR_GREATER
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+	public sealed class IsReady
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveIsReady_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetIsReady(true));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).IsReady();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveIsNotReady_ShouldFail()
+			{
+				MockFileSystem fileSystem = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				fileSystem.WithDrive("D:", d => d.SetIsReady(false));
+				IDriveInfo driveInfo = fileSystem.DriveInfo.New("D:");
+
+				async Task Act()
+				{
+					await That(driveInfo).IsReady();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that driveInfo
+					             is ready,
+					             but it was not
+					             """);
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/DriveInfo.cs
+++ b/Tests/aweXpect.Testably.Tests/DriveInfo.cs
@@ -1,0 +1,5 @@
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DriveInfo
+{
+}

--- a/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDrive.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.DoesNotHaveDrive.Tests.cs
@@ -1,0 +1,47 @@
+#if NET8_0_OR_GREATER
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed class DoesNotHaveDrive
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveExists_ShouldFail()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				sut.WithDrive("D:");
+
+				async Task Act()
+				{
+					await That(sut).DoesNotHaveDrive("D:\\");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             does not have drive 'D:\',
+					             but it did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenDriveIsMissing_ShouldSucceed()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+
+				async Task Act()
+				{
+					await That(sut).DoesNotHaveDrive("Z:\\");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.Tests.cs
@@ -1,0 +1,75 @@
+#if NET8_0_OR_GREATER
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed partial class HasDrive
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenDriveExists_ShouldSucceed()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				sut.WithDrive("D:");
+
+				async Task Act()
+				{
+					await That(sut).HasDrive("D:\\");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveNameDiffersInCase_ShouldSucceed()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				sut.WithDrive("D:");
+
+				async Task Act()
+				{
+					await That(sut).HasDrive("d:\\");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveNameMissesTrailingSeparator_ShouldSucceed()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+				sut.WithDrive("D:");
+
+				async Task Act()
+				{
+					await That(sut).HasDrive("D:");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDriveIsMissing_ShouldFail()
+			{
+				MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+
+				async Task Act()
+				{
+					await That(sut).HasDrive("Z:\\");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             has drive 'Z:\',
+					             but it did not exist
+					             """);
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.Which.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.Which.Tests.cs
@@ -1,0 +1,84 @@
+#if NET8_0_OR_GREATER
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed partial class HasDrive
+	{
+		public sealed class Which
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task IsReady_WhenDriveIsReady_ShouldSucceed()
+				{
+					MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+					sut.WithDrive("D:");
+
+					async Task Act()
+					{
+						await That(sut).HasDrive("D:\\").Which.IsReady();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task HasTotalSize_WhenSizeDiffers_ShouldFail()
+				{
+					MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+					sut.WithDrive("D:", d => d.SetTotalSize(2048));
+
+					async Task Act()
+					{
+						await That(sut).HasDrive("D:\\").Which.HasTotalSize(1024);
+					}
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that sut
+						             has drive 'D:\' which has total size 1024,
+						             but it was 2048
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenDriveIsMissing_ChainedExpectation_ShouldFailWithoutNullReference()
+				{
+					MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+
+					async Task Act()
+					{
+						await That(sut).HasDrive("Z:\\").Which.HasTotalSize(1024);
+					}
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that sut
+						             has drive 'Z:\' which has total size 1024,
+						             but it did not exist
+						             """);
+				}
+
+				[Fact]
+				public async Task ChainedAnd_HasTotalSize_And_IsReady_ShouldSucceed()
+				{
+					MockFileSystem sut = new(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+					sut.WithDrive("D:", d => d.SetTotalSize(4096));
+
+					async Task Act()
+					{
+						await That(sut).HasDrive("D:\\")
+							.Which.HasTotalSize(4096).And.IsReady();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}
+
+#endif

--- a/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.cs
+++ b/Tests/aweXpect.Testably.Tests/FileSystem.HasDrive.cs
@@ -1,0 +1,8 @@
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileSystem
+{
+	public sealed partial class HasDrive
+	{
+	}
+}


### PR DESCRIPTION
This pull request adds comprehensive support for drive-level assertions to the testing library, both in documentation and implementation. It introduces new extension methods for asserting properties of `IDriveInfo` objects, such as drive existence, readiness, size, format, and more. The documentation is updated to demonstrate these new capabilities, and the codebase now includes several new files implementing these assertions.

**Drive assertion support:**

* Added `HasDrive` and `DoesNotHaveDrive` extension methods to `IFileSystem` for asserting the presence or absence of drives by name, with case-insensitive matching and `.Which` chaining to access `IDriveInfo` assertions.
* Introduced a new partial class `DriveInfoExtensions` as the container for all drive-related assertion extensions. 

**Drive property assertions:**

* Added extension methods to `IThat<IDriveInfo>` for asserting drive properties:
  - `IsReady` and `IsNotReady` to check drive readiness
  - `HasTotalSize`, `HasTotalFreeSpace`, and `HasAvailableFreeSpace` for size-related assertions
  - `HasDriveFormat`, `HasDriveType`, `HasName`, and `HasVolumeLabel` for format, type, name, and label assertions

**Documentation updates:**

* Expanded the `README.md` with a new "Drives" section, including usage examples for the new drive assertions and `.Which` chaining.
* Updated documentation for `.Which` to include `HasDrive` in addition to `HasFile` and `HasDirectory`.

These changes significantly enhance the ability to write expressive and comprehensive tests involving file system drives.