### PR TITLE
feat: add file version info expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,36 @@ await That(fileSystem).HasFile("my-file.txt").Which.HasLength(12).And.HasContent
 await That(fileSystem).HasDirectory("logs").Which.IsEmpty();
 ```
 
+### IFileVersionInfo
+
+`IFileVersionInfo` instances obtained via `MockFileSystem.FileVersionInfo.GetVersionInfo`
+can be asserted directly. The configured values come from
+`MockFileSystem.WithFileVersionInfo(glob, builder)`:
+
+```csharp
+MockFileSystem fileSystem = new();
+fileSystem.WithFileVersionInfo("*.dll", v => v
+    .SetCompanyName("Acme")
+    .SetProductName("Anvil")
+    .SetFileVersion("1.2.3.4")
+    .SetIsDebug(true));
+fileSystem.File.WriteAllText("Acme.dll", "");
+
+IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+await That(info).HasCompanyName("Acme").And.HasProductName("Anvil");
+await That(info).HasFileVersion("1.2.3.4");
+await That(info).IsDebug().And.IsNotPreRelease();
+```
+
+The following common fields have dedicated assertions:
+`HasCompanyName`, `HasProductName`, `HasFileDescription`, `HasFileVersion`,
+`HasProductVersion`, `HasOriginalFilename`, `HasLanguage`, plus the bool pairs
+`IsDebug` / `IsNotDebug`, `IsPreRelease` / `IsNotPreRelease`,
+`IsPatched` / `IsNotPatched`. For the remaining properties (e.g. `Comments`,
+`LegalCopyright`, `FileMajorPart`), assert on them directly via
+`await That(info.LegalCopyright).IsEqualTo("…")`.
+
 ### Notifications
 
 A `MockFileSystem` raises notifications when files or directories change. Run

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasCompanyName.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasCompanyName.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> company name.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasCompanyName(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.CompanyName, options, expected, "company name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasFileDescription.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasFileDescription.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> file description.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasFileDescription(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.FileDescription, options, expected, "file description")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasFileVersion.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasFileVersion.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> file version.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasFileVersion(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.FileVersion, options, expected, "file version")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasLanguage.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasLanguage.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> language.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasLanguage(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.Language, options, expected, "language")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasOriginalFilename.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasOriginalFilename.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> original filename.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasOriginalFilename(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.OriginalFilename, options, expected, "original filename")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasProductName.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasProductName.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> product name.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasProductName(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.ProductName, options, expected, "product name")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.HasProductVersion.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.HasProductVersion.cs
@@ -1,0 +1,26 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> has the <paramref name="expected" /> product version.
+	/// </summary>
+	public static StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>> HasProductVersion(
+		this IThat<IFileVersionInfo> source,
+		string? expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IFileVersionInfo, IThat<IFileVersionInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasStringPropertyConstraint(
+					it, grammars, v => v.ProductVersion, options, expected, "product version")),
+			source,
+			options);
+	}
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.IsDebug.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.IsDebug.cs
@@ -1,0 +1,30 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is a debug build.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsDebug(this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsDebug, "is debug", "is not debug")),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is not a debug build.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsNotDebug(this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsDebug, "is debug", "is not debug").Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.IsPatched.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.IsPatched.cs
@@ -1,0 +1,31 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is patched.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsPatched(this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsPatched, "is patched", "is not patched")),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is not patched.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsNotPatched(
+		this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsPatched, "is patched", "is not patched").Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.IsPreRelease.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.IsPreRelease.cs
@@ -1,0 +1,32 @@
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class FileVersionInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is a pre-release.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsPreRelease(
+		this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsPreRelease, "is pre-release", "is not pre-release")),
+			source);
+
+	/// <summary>
+	///     Verifies that the <see cref="IFileVersionInfo" /> is not a pre-release.
+	/// </summary>
+	public static AndOrResult<IFileVersionInfo, IThat<IFileVersionInfo>> IsNotPreRelease(
+		this IThat<IFileVersionInfo> source)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileVersionInfoConstraints.HasBoolPropertyConstraint(
+					it, grammars, v => v.IsPreRelease, "is pre-release", "is not pre-release").Invert()),
+			source);
+}

--- a/Source/aweXpect.Testably/FileVersionInfoExtensions.cs
+++ b/Source/aweXpect.Testably/FileVersionInfoExtensions.cs
@@ -1,0 +1,10 @@
+using System.IO.Abstractions;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="IFileVersionInfo" />.
+/// </summary>
+public static partial class FileVersionInfoExtensions
+{
+}

--- a/Source/aweXpect.Testably/Helpers/FileVersionInfoConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/FileVersionInfoConstraints.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO.Abstractions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+
+namespace aweXpect.Testably.Helpers;
+
+internal static class FileVersionInfoConstraints
+{
+	internal sealed class HasStringPropertyConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<IFileVersionInfo, string?> selector,
+		StringEqualityOptions options,
+		string? expected,
+		string propertyName)
+		: ConstraintResult.WithValue<IFileVersionInfo>(grammars),
+			IAsyncConstraint<IFileVersionInfo>
+	{
+		private string? _actualValue;
+
+		public async Task<ConstraintResult> IsMetBy(IFileVersionInfo actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualValue = selector(actual);
+			Outcome = await options.AreConsideredEqual(_actualValue, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(options.GetExtendedFailure(it, Grammars, _actualValue, expected));
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have ").Append(propertyName).Append(' ')
+				.Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	internal sealed class HasBoolPropertyConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<IFileVersionInfo, bool> selector,
+		string normalExpectation,
+		string negatedExpectation)
+		: ConstraintResult.WithValue<IFileVersionInfo>(grammars),
+			IValueConstraint<IFileVersionInfo>
+	{
+		public ConstraintResult IsMetBy(IFileVersionInfo actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			Outcome = selector(actual) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(normalExpectation);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was not");
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(negatedExpectation);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -90,6 +90,22 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileVersionInfoExtensions
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasCompanyName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileDescription(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasLanguage(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasOriginalFilename(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+    }
     public static class StatisticsExtensions
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -80,6 +80,22 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileVersionInfoExtensions
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasCompanyName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileDescription(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasLanguage(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasOriginalFilename(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+    }
     public static class StatisticsExtensions
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -80,6 +80,22 @@ namespace aweXpect.Testably
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject) { }
         public static aweXpect.Testably.Results.TriggeredWatcherResult Triggered(this aweXpect.Core.IThat<System.IO.Abstractions.IFileSystemWatcher> subject, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
+    public static class FileVersionInfoExtensions
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasCompanyName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileDescription(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasFileVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasLanguage(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasOriginalFilename(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductName(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> HasProductVersion(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source, string? expected) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotDebug(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsNotPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPatched(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileVersionInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo>> IsPreRelease(this aweXpect.Core.IThat<System.IO.Abstractions.IFileVersionInfo> source) { }
+    }
     public static class StatisticsExtensions
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasCompanyName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasCompanyName.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasCompanyName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenCompanyNameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasCompanyName("Contoso");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has company name equal to "Contoso",
+					             but it was "Acme" which differs at index 0:
+					                ↓ (actual)
+					               "Acme"
+					               "Contoso"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenCompanyNameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetCompanyName("Acme")
+					.SetProductName("Anvil"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasCompanyName("Acme").And.HasProductName("Anvil");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasFileDescription.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasFileDescription.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasFileDescription
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFileDescriptionDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetFileDescription("Acme runtime"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileDescription("Other");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has file description equal to "Other",
+					             but it was "Acme runtime" which differs at index 0:
+					                ↓ (actual)
+					               "Acme runtime"
+					               "Other"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFileDescriptionMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetFileDescription("Acme runtime"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileDescription("Acme runtime");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetFileDescription("Acme runtime")
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileDescription("Acme runtime").And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasFileVersion.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasFileVersion.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasFileVersion
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFileVersionDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetFileVersion("1.2.3.4"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileVersion("9.9.9.9");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has file version equal to "9.9.9.9",
+					             but it was "1.2.3.4" which differs at index 0:
+					                ↓ (actual)
+					               "1.2.3.4"
+					               "9.9.9.9"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFileVersionMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetFileVersion("1.2.3.4"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileVersion("1.2.3.4");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetFileVersion("1.2.3.4")
+					.SetProductVersion("1.2"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasFileVersion("1.2.3.4").And.HasProductVersion("1.2");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasLanguage.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasLanguage.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasLanguage
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenLanguageDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetLanguage("English (United States)"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasLanguage("German (Germany)");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has language equal to "German (Germany)",
+					             but it was "English (United States)" which differs at index 0:
+					                ↓ (actual)
+					               "English (United States)"
+					               "German (Germany)"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenLanguageMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetLanguage("English (United States)"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasLanguage("English (United States)");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetLanguage("English (United States)")
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasLanguage("English (United States)").And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasOriginalFilename.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasOriginalFilename.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasOriginalFilename
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenOriginalFilenameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetOriginalFilename("Acme.dll"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasOriginalFilename("Other.dll");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has original filename equal to "Other.dll",
+					             but it was "Acme.dll" which differs at index 0:
+					                ↓ (actual)
+					               "Acme.dll"
+					               "Other.dll"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenOriginalFilenameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetOriginalFilename("Acme.dll"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasOriginalFilename("Acme.dll");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetOriginalFilename("Acme.dll")
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasOriginalFilename("Acme.dll").And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasProductName.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasProductName.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasProductName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenProductNameDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetProductName("Anvil"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductName("Rocket");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has product name equal to "Rocket",
+					             but it was "Anvil" which differs at index 0:
+					                ↓ (actual)
+					               "Anvil"
+					               "Rocket"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenProductNameMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetProductName("Anvil"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductName("Anvil");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetProductName("Anvil")
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductName("Anvil").And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasProductVersion.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.HasProductVersion.Tests.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class HasProductVersion
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenProductVersionDiffers_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetProductVersion("1.2"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductVersion("9.9");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             has product version equal to "9.9",
+					             but it was "1.2" which differs at index 0:
+					                ↓ (actual)
+					               "1.2"
+					               "9.9"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenProductVersionMatches_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetProductVersion("1.2"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductVersion("1.2");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetProductVersion("1.2")
+					.SetFileVersion("1.2.3.4"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).HasProductVersion("1.2").And.HasFileVersion("1.2.3.4");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsDebug.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsDebug.Tests.cs
@@ -1,0 +1,135 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class IsDebug
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsDebug_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsDebug(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsDebug();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsNotDebug_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsDebug(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsDebug();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is debug,
+					             but it was not
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsDebug(true)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsDebug().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+
+	public sealed class IsNotDebug
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsNotDebug_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsDebug(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotDebug();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsDebug_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsDebug(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotDebug();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is not debug,
+					             but it was
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsDebug(false)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotDebug().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsPatched.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsPatched.Tests.cs
@@ -1,0 +1,135 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class IsPatched
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsPatched_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPatched(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPatched();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsNotPatched_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPatched(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPatched();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is patched,
+					             but it was not
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsPatched(true)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPatched().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+
+	public sealed class IsNotPatched
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsNotPatched_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPatched(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPatched();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsPatched_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPatched(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPatched();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is not patched,
+					             but it was
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsPatched(false)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPatched().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsPreRelease.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.IsPreRelease.Tests.cs
@@ -1,0 +1,135 @@
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+	public sealed class IsPreRelease
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsPreRelease_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPreRelease(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPreRelease();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsNotPreRelease_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPreRelease(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPreRelease();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is pre-release,
+					             but it was not
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsPreRelease(true)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsPreRelease().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+
+	public sealed class IsNotPreRelease
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenInfoIsNotPreRelease_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPreRelease(false));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPreRelease();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInfoIsPreRelease_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v.SetIsPreRelease(true));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPreRelease();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that info
+					             is not pre-release,
+					             but it was
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportAndComposition()
+			{
+				MockFileSystem fileSystem = new();
+				fileSystem.WithFileVersionInfo("*.dll", v => v
+					.SetIsPreRelease(false)
+					.SetCompanyName("Acme"));
+				// ReSharper disable once MethodHasAsyncOverload
+				fileSystem.File.WriteAllText("Acme.dll", "");
+				IFileVersionInfo info = fileSystem.FileVersionInfo.GetVersionInfo("Acme.dll");
+
+				async Task Act()
+				{
+					await That(info).IsNotPreRelease().And.HasCompanyName("Acme");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileVersionInfo.cs
+++ b/Tests/aweXpect.Testably.Tests/FileVersionInfo.cs
@@ -1,0 +1,5 @@
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileVersionInfo
+{
+}


### PR DESCRIPTION
This PR introduces first-class aweXpect assertions for `System.IO.Abstractions.IFileVersionInfo` (as produced by `MockFileSystem.FileVersionInfo.GetVersionInfo`) and documents their intended usage.

**Changes:**
- Added `FileVersionInfoExtensions` APIs for common string properties (e.g., company/product/file versions) and boolean flags (debug/pre-release/patched).
- Added shared internal constraints (`FileVersionInfoConstraints`) to implement consistent string/bool expectation formatting and inversion behavior.
- Added unit tests for the new expectations, updated Public API snapshots, and documented the feature in the README.