### PR TITLE
feat: add timer executed expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,27 @@ await That(change).HasNotifyFilters(NotifyFilters.LastWrite);
 await That(change).HasName("my-file.txt").And.HasPath("/abs/my-file.txt");
 await That(renamedChange).HasOldName("old.txt").And.HasOldPath("/abs/old.txt");
 ```
+
+## Time system
+
+### Timers
+
+A `MockTimeSystem` exposes timers as `ITimerMock`. You can assert how often the
+timer callback was executed without blocking the test thread:
+
+```csharp
+MockTimeSystem timeSystem = new();
+ITimerMock timer = (ITimerMock)timeSystem.Timer.New(
+    _ => { }, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
+
+await That(timer).Executed(3.Times()).Within(5.Seconds());
+```
+
+`Executed()` accepts a `Quantifier` (`AtLeast`, `AtMost`, `Exactly`,
+`Between`, …) and exposes `.Within(timeout)` for asynchronous execution. The
+assertion polls `ITimerMock.ExecutionCount` until the quantifier is satisfied
+or the timeout expires — 30 seconds by default.
+
+```csharp
+await That(timer).Executed().AtLeast(2.Times()).Within(100.Milliseconds());
+```

--- a/Source/aweXpect.Testably/Helpers/TimerConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/TimerConstraints.cs
@@ -76,23 +76,30 @@ internal static class TimerConstraints
 			=> value > int.MaxValue ? int.MaxValue : (int)value;
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("executed");
-			stringBuilder.Append(' ').Append(quantifier);
-			stringBuilder.Append(options);
-		}
+			=> AppendExpectation(stringBuilder, false);
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendCount(stringBuilder);
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("did not execute");
-			stringBuilder.Append(options);
-		}
+			=> AppendExpectation(stringBuilder, true);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendCount(stringBuilder);
+
+		private void AppendExpectation(StringBuilder stringBuilder, bool negated)
+		{
+			if (quantifier.IsNever)
+			{
+				stringBuilder.Append(negated ? "executed at least once" : "did not execute");
+			}
+			else
+			{
+				stringBuilder.Append(negated ? "did not execute " : "executed ").Append(quantifier);
+			}
+
+			stringBuilder.Append(options);
+		}
 
 		private void AppendCount(StringBuilder stringBuilder)
 		{

--- a/Source/aweXpect.Testably/Helpers/TimerConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/TimerConstraints.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Options;
+using Testably.Abstractions.Testing.TimeSystem;
+
+namespace aweXpect.Testably.Helpers;
+
+internal static class TimerConstraints
+{
+	internal sealed class TimerExecutedConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options)
+		: ConstraintResult.WithValue<ITimerMock>(grammars),
+			IAsyncContextConstraint<ITimerMock>
+	{
+		private long _executionCount;
+
+		public async Task<ConstraintResult> IsMetBy(ITimerMock actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			TimeSpan timeout = options.Timeout;
+			using CancellationTokenSource deadlineCts =
+				CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			deadlineCts.CancelAfter(timeout);
+			CancellationToken deadlineToken = deadlineCts.Token;
+
+			TimeSpan pollInterval = TimeSpan.FromMilliseconds(10);
+			while (true)
+			{
+				_executionCount = actual.ExecutionCount;
+				if (quantifier.Check(ToInt(_executionCount), false) is not null)
+				{
+					break;
+				}
+
+				if (deadlineToken.IsCancellationRequested)
+				{
+					break;
+				}
+
+				try
+				{
+					await Task.Delay(pollInterval, deadlineToken).ConfigureAwait(false);
+				}
+				catch (OperationCanceledException)
+				{
+					// deadline hit
+				}
+			}
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			_executionCount = actual.ExecutionCount;
+			Outcome = quantifier.Check(ToInt(_executionCount), true) == true
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		private static int ToInt(long value)
+			=> value > int.MaxValue ? int.MaxValue : (int)value;
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("executed");
+			stringBuilder.Append(' ').Append(quantifier);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder);
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("did not execute");
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendCount(stringBuilder);
+
+		private void AppendCount(StringBuilder stringBuilder)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+				return;
+			}
+
+			stringBuilder.Append(it).Append(" was ");
+			if (_executionCount == 0)
+			{
+				stringBuilder.Append("not executed");
+				return;
+			}
+
+			stringBuilder.Append("executed ");
+			AppendTimes(stringBuilder, _executionCount);
+		}
+
+		private static void AppendTimes(StringBuilder stringBuilder, long count)
+		{
+			switch (count)
+			{
+				case 1:
+					stringBuilder.Append("once");
+					break;
+				case 2:
+					stringBuilder.Append("twice");
+					break;
+				default:
+					stringBuilder.Append(count).Append(" times");
+					break;
+			}
+		}
+	}
+}

--- a/Source/aweXpect.Testably/Results/TimerExecutedResult.cs
+++ b/Source/aweXpect.Testably/Results/TimerExecutedResult.cs
@@ -1,0 +1,36 @@
+using System;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+using Testably.Abstractions.Testing.TimeSystem;
+
+namespace aweXpect.Testably.Results;
+
+/// <summary>
+///     The result for <see cref="TimerExtensions.Executed(aweXpect.Core.IThat{ITimerMock})" />.
+/// </summary>
+public class TimerExecutedResult
+	: CountResult<ITimerMock, IThat<ITimerMock>, TimerExecutedResult>
+{
+	private readonly NotificationTimeoutOptions _options;
+
+	internal TimerExecutedResult(
+		ExpectationBuilder expectationBuilder,
+		IThat<ITimerMock> subject,
+		Quantifier quantifier,
+		NotificationTimeoutOptions options)
+		: base(expectationBuilder, subject, quantifier)
+	{
+		_options = options;
+	}
+
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> for waiting for asynchronous timer executions.
+	/// </summary>
+	public TimerExecutedResult Within(TimeSpan timeout)
+	{
+		_options.Within(timeout);
+		return this;
+	}
+}

--- a/Source/aweXpect.Testably/TimerExtensions.cs
+++ b/Source/aweXpect.Testably/TimerExtensions.cs
@@ -22,20 +22,6 @@ public static class TimerExtensions
 		this IThat<ITimerMock> subject)
 		=> ExecutedCore(subject, null);
 
-	/// <summary>
-	///     Verifies that the <see cref="ITimerMock" /> callback was executed exactly
-	///     <paramref name="times" />.
-	/// </summary>
-	/// <remarks>
-	///     Convenience for <c>.Executed().Exactly(times)</c>. Polls
-	///     <see cref="ITimerMock.ExecutionCount" /> until either the quantifier is satisfied or the
-	///     timeout expires — 30 seconds by default; use <c>.Within(timeout)</c> to override.
-	/// </remarks>
-	public static TimerExecutedResult Executed(
-		this IThat<ITimerMock> subject,
-		Times times)
-		=> ExecutedCore(subject, times);
-
 	private static TimerExecutedResult ExecutedCore(
 		IThat<ITimerMock> subject,
 		Times? times)

--- a/Source/aweXpect.Testably/TimerExtensions.cs
+++ b/Source/aweXpect.Testably/TimerExtensions.cs
@@ -1,0 +1,57 @@
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Testably.Helpers;
+using aweXpect.Testably.Results;
+using Testably.Abstractions.Testing.TimeSystem;
+
+namespace aweXpect.Testably;
+
+/// <summary>
+///     Extensions for <see cref="ITimerMock" />.
+/// </summary>
+public static class TimerExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="ITimerMock" /> callback was executed.
+	/// </summary>
+	/// <remarks>
+	///     Polls <see cref="ITimerMock.ExecutionCount" /> until either the quantifier is satisfied
+	///     or the timeout expires — 30 seconds by default; use <c>.Within(timeout)</c> to override.
+	/// </remarks>
+	public static TimerExecutedResult Executed(
+		this IThat<ITimerMock> subject)
+		=> ExecutedCore(subject, null);
+
+	/// <summary>
+	///     Verifies that the <see cref="ITimerMock" /> callback was executed exactly
+	///     <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     Convenience for <c>.Executed().Exactly(times)</c>. Polls
+	///     <see cref="ITimerMock.ExecutionCount" /> until either the quantifier is satisfied or the
+	///     timeout expires — 30 seconds by default; use <c>.Within(timeout)</c> to override.
+	/// </remarks>
+	public static TimerExecutedResult Executed(
+		this IThat<ITimerMock> subject,
+		Times times)
+		=> ExecutedCore(subject, times);
+
+	private static TimerExecutedResult ExecutedCore(
+		IThat<ITimerMock> subject,
+		Times? times)
+	{
+		Quantifier quantifier = new();
+		if (times.HasValue)
+		{
+			quantifier.Exactly(times.Value.Value);
+		}
+
+		NotificationTimeoutOptions options = new();
+		return new TimerExecutedResult(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new TimerConstraints.TimerExecutedConstraint(it, grammars, quantifier, options)),
+			subject,
+			quantifier,
+			options);
+	}
+}

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -93,6 +93,11 @@ namespace aweXpect.Testably
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }
     }
+    public static class TimerExtensions
+    {
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
+    }
 }
 namespace aweXpect.Testably.Recorded
 {
@@ -468,6 +473,10 @@ namespace aweXpect.Testably.Results
     }
     public sealed class RecordedMethodCallResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedMethodCallResult> { }
     public sealed class RecordedPropertyAccessResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedPropertyAccessResult> { }
+    public class TimerExecutedResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.TimeSystem.ITimerMock, aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock>, aweXpect.Testably.Results.TimerExecutedResult>
+    {
+        public aweXpect.Testably.Results.TimerExecutedResult Within(System.TimeSpan timeout) { }
+    }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -96,7 +96,6 @@ namespace aweXpect.Testably
     public static class TimerExtensions
     {
         public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
-        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
     }
 }
 namespace aweXpect.Testably.Recorded

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -86,7 +86,6 @@ namespace aweXpect.Testably
     public static class TimerExtensions
     {
         public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
-        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
     }
 }
 namespace aweXpect.Testably.Recorded

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -83,6 +83,11 @@ namespace aweXpect.Testably
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }
     }
+    public static class TimerExtensions
+    {
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
+    }
 }
 namespace aweXpect.Testably.Recorded
 {
@@ -458,6 +463,10 @@ namespace aweXpect.Testably.Results
     }
     public sealed class RecordedMethodCallResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedMethodCallResult> { }
     public sealed class RecordedPropertyAccessResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedPropertyAccessResult> { }
+    public class TimerExecutedResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.TimeSystem.ITimerMock, aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock>, aweXpect.Testably.Results.TimerExecutedResult>
+    {
+        public aweXpect.Testably.Results.TimerExecutedResult Within(System.TimeSpan timeout) { }
+    }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -83,6 +83,11 @@ namespace aweXpect.Testably
     {
         public static aweXpect.Testably.Recorded.RecordedFileSystemStatistics Recorded(this aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics> subject) { }
     }
+    public static class TimerExtensions
+    {
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
+        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
+    }
 }
 namespace aweXpect.Testably.Recorded
 {
@@ -456,6 +461,10 @@ namespace aweXpect.Testably.Results
     }
     public sealed class RecordedMethodCallResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedMethodCallResult> { }
     public sealed class RecordedPropertyAccessResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics, aweXpect.Core.IThat<Testably.Abstractions.Testing.Statistics.IFileSystemStatistics>, aweXpect.Testably.Results.RecordedPropertyAccessResult> { }
+    public class TimerExecutedResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.TimeSystem.ITimerMock, aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock>, aweXpect.Testably.Results.TimerExecutedResult>
+    {
+        public aweXpect.Testably.Results.TimerExecutedResult Within(System.TimeSpan timeout) { }
+    }
     public class TriggeredNotificationResult : aweXpect.Results.CountResult<Testably.Abstractions.Testing.MockFileSystem, aweXpect.Core.IThat<Testably.Abstractions.Testing.MockFileSystem>, aweXpect.Testably.Results.TriggeredNotificationResult>
     {
         public aweXpect.Testably.Results.TriggeredNotificationResult Which(System.Action<aweXpect.Core.IThat<Testably.Abstractions.Testing.FileSystem.ChangeDescription>> expectation) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -86,7 +86,6 @@ namespace aweXpect.Testably
     public static class TimerExtensions
     {
         public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject) { }
-        public static aweXpect.Testably.Results.TimerExecutedResult Executed(this aweXpect.Core.IThat<Testably.Abstractions.Testing.TimeSystem.ITimerMock> subject, aweXpect.Core.Times times) { }
     }
 }
 namespace aweXpect.Testably.Recorded

--- a/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
@@ -1,0 +1,146 @@
+using System.Threading;
+using aweXpect.Core;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.TimeSystem;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class Timer
+{
+	public sealed class Executed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAutoAdvanceTriggersExecutions_ShouldSucceedSynchronously()
+			{
+				MockTimeSystem timeSystem = new();
+				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					TimeSpan.Zero,
+					TimeSpan.FromMilliseconds(1));
+
+				async Task Act()
+				{
+					await That(sut).Executed().AtLeast(3.Times()).Within(TimeSpan.FromSeconds(30));
+				}
+
+				await That(Act).DoesNotThrow();
+
+				sut.Dispose();
+			}
+
+			[Fact]
+			public async Task WhenExecutionCountReachesThreshold_ShouldSucceed()
+			{
+				MockTimeSystem timeSystem = new();
+				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					TimeSpan.Zero,
+					TimeSpan.FromMilliseconds(1));
+				sut.Wait(3, 5000);
+
+				async Task Act()
+				{
+					await That(sut).Executed().AtLeast(3.Times()).Within(TimeSpan.FromSeconds(30));
+				}
+
+				await That(Act).DoesNotThrow();
+
+				sut.Dispose();
+			}
+
+			[Fact]
+			public async Task WhenInsufficientExecutions_ShouldFailAfterTimeout()
+			{
+				MockTimeSystem timeSystem = new();
+				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					Timeout.InfiniteTimeSpan,
+					Timeout.InfiniteTimeSpan);
+
+				async Task Act()
+				{
+					await That(sut).Executed(3.Times()).Within(TimeSpan.FromMilliseconds(100));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             executed exactly 3 times within 0:00.100,
+					             but it was not executed
+					             """);
+
+				sut.Dispose();
+			}
+
+			[Fact]
+			public async Task WhenLiveExecutionsArriveDuringWithin_ShouldSucceed()
+			{
+				MockTimeSystem timeSystem = new();
+				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					Timeout.InfiniteTimeSpan,
+					Timeout.InfiniteTimeSpan);
+
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(20);
+					sut.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(5));
+				});
+
+				async Task Act()
+				{
+					await That(sut).Executed().AtLeast(2.Times()).Within(TimeSpan.FromSeconds(5));
+				}
+
+				await That(Act).DoesNotThrow();
+
+				sut.Dispose();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				ITimerMock? sut = null;
+
+				async Task Act()
+				{
+					await That(sut!).Executed(1.Times()).Within(TimeSpan.FromMilliseconds(10));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             executed exactly once within 0:00.010,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithoutQuantifier_WhenExecutedAtLeastOnce_ShouldSucceed()
+			{
+				MockTimeSystem timeSystem = new();
+				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					TimeSpan.Zero,
+					TimeSpan.FromMilliseconds(1));
+				sut.Wait(1, 5000);
+
+				async Task Act()
+				{
+					await That(sut).Executed().Within(TimeSpan.FromSeconds(30));
+				}
+
+				await That(Act).DoesNotThrow();
+
+				sut.Dispose();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
@@ -105,13 +105,12 @@ public sealed class Timer
 			[Fact]
 			public async Task WhenNegated_AndExecuted_ShouldFail()
 			{
-				MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+				MockTimeSystem timeSystem = new();
 				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					TimeSpan.Zero,
-					Timeout.InfiniteTimeSpan);
-				timeSystem.TimeProvider.AdvanceBy(TimeSpan.Zero);
+					TimeSpan.FromMilliseconds(1));
 				sut.Wait(1, 5000);
 
 				async Task Act()
@@ -122,23 +121,18 @@ public sealed class Timer
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that sut
-					             did not execute at least once within 0:00.100,
-					             but it was executed once
-					             """);
+					.WithMessage("*did not execute at least once within 0:00.100*").AsWildcard();
 			}
 
 			[Fact]
 			public async Task WhenNegatedWithAtLeastQuantifier_ShouldIncludeQuantifierInMessage()
 			{
-				MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+				MockTimeSystem timeSystem = new();
 				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					TimeSpan.Zero,
-					TimeSpan.FromMilliseconds(10));
-				timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromMilliseconds(25));
+					TimeSpan.FromMilliseconds(1));
 				sut.Wait(3, 5000);
 
 				async Task Act()
@@ -149,11 +143,7 @@ public sealed class Timer
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that sut
-					             did not execute at least 3 times within 0:00.100,
-					             but it was executed 3 times
-					             """);
+					.WithMessage("*did not execute at least 3 times within 0:00.100*").AsWildcard();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using aweXpect.Core;
 using Testably.Abstractions.Testing;
 using Testably.Abstractions.Testing.TimeSystem;
+
 // ReSharper disable UseAwaitUsing
 
 namespace aweXpect.Testably.Tests;
@@ -99,6 +100,85 @@ public sealed class Timer
 				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNegated_AndExecuted_ShouldFail()
+			{
+				MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					TimeSpan.Zero,
+					Timeout.InfiniteTimeSpan);
+				timeSystem.TimeProvider.AdvanceBy(TimeSpan.Zero);
+				sut.Wait(1, 5000);
+
+				async Task Act()
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					await That(sut).DoesNotComplyWith(it
+						=> it.Executed().Within(TimeSpan.FromMilliseconds(100)));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             did not execute at least once within 0:00.100,
+					             but it was executed once
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegatedWithAtLeastQuantifier_ShouldIncludeQuantifierInMessage()
+			{
+				MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					TimeSpan.Zero,
+					TimeSpan.FromMilliseconds(10));
+				timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromMilliseconds(25));
+				sut.Wait(3, 5000);
+
+				async Task Act()
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					await That(sut).DoesNotComplyWith(it
+						=> it.Executed().AtLeast(3.Times()).Within(TimeSpan.FromMilliseconds(100)));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             did not execute at least 3 times within 0:00.100,
+					             but it was executed 3 times
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNegatedWithNeverQuantifier_AndNotExecuted_ShouldFail()
+			{
+				MockTimeSystem timeSystem = new();
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+					_ => { },
+					null,
+					Timeout.InfiniteTimeSpan,
+					Timeout.InfiniteTimeSpan);
+
+				async Task Act()
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					await That(sut).DoesNotComplyWith(it
+						=> it.Executed().Never().Within(TimeSpan.FromMilliseconds(100)));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that sut
+					             executed at least once within 0:00.100,
+					             but it was not executed
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
@@ -2,10 +2,11 @@ using System.Threading;
 using aweXpect.Core;
 using Testably.Abstractions.Testing;
 using Testably.Abstractions.Testing.TimeSystem;
+// ReSharper disable UseAwaitUsing
 
 namespace aweXpect.Testably.Tests;
 
-public sealed partial class Timer
+public sealed class Timer
 {
 	public sealed class Executed
 	{
@@ -15,7 +16,7 @@ public sealed partial class Timer
 			public async Task WhenAutoAdvanceTriggersExecutions_ShouldSucceedSynchronously()
 			{
 				MockTimeSystem timeSystem = new();
-				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					TimeSpan.Zero,
@@ -23,19 +24,18 @@ public sealed partial class Timer
 
 				async Task Act()
 				{
+					// ReSharper disable once AccessToDisposedClosure
 					await That(sut).Executed().AtLeast(3.Times()).Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
-
-				sut.Dispose();
 			}
 
 			[Fact]
 			public async Task WhenExecutionCountReachesThreshold_ShouldSucceed()
 			{
 				MockTimeSystem timeSystem = new();
-				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					TimeSpan.Zero,
@@ -44,19 +44,18 @@ public sealed partial class Timer
 
 				async Task Act()
 				{
+					// ReSharper disable once AccessToDisposedClosure
 					await That(sut).Executed().AtLeast(3.Times()).Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
-
-				sut.Dispose();
 			}
 
 			[Fact]
 			public async Task WhenInsufficientExecutions_ShouldFailAfterTimeout()
 			{
 				MockTimeSystem timeSystem = new();
-				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					Timeout.InfiniteTimeSpan,
@@ -64,7 +63,8 @@ public sealed partial class Timer
 
 				async Task Act()
 				{
-					await That(sut).Executed(3.Times()).Within(TimeSpan.FromMilliseconds(100));
+					// ReSharper disable once AccessToDisposedClosure
+					await That(sut).Executed().Within(TimeSpan.FromMilliseconds(100)).Exactly(3.Times());
 				}
 
 				await That(Act).ThrowsException()
@@ -73,15 +73,13 @@ public sealed partial class Timer
 					             executed exactly 3 times within 0:00.100,
 					             but it was not executed
 					             """);
-
-				sut.Dispose();
 			}
 
 			[Fact]
 			public async Task WhenLiveExecutionsArriveDuringWithin_ShouldSucceed()
 			{
 				MockTimeSystem timeSystem = new();
-				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					Timeout.InfiniteTimeSpan,
@@ -90,17 +88,17 @@ public sealed partial class Timer
 				_ = Task.Run(async () =>
 				{
 					await Task.Delay(20);
+					// ReSharper disable once AccessToDisposedClosure
 					sut.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(5));
 				});
 
 				async Task Act()
 				{
+					// ReSharper disable once AccessToDisposedClosure
 					await That(sut).Executed().AtLeast(2.Times()).Within(TimeSpan.FromSeconds(5));
 				}
 
 				await That(Act).DoesNotThrow();
-
-				sut.Dispose();
 			}
 
 			[Fact]
@@ -110,13 +108,13 @@ public sealed partial class Timer
 
 				async Task Act()
 				{
-					await That(sut!).Executed(1.Times()).Within(TimeSpan.FromMilliseconds(10));
+					await That(sut!).Executed().Within(TimeSpan.FromMilliseconds(10));
 				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that sut
-					             executed exactly once within 0:00.010,
+					             executed at least once within 0:00.010,
 					             but it was <null>
 					             """);
 			}
@@ -125,7 +123,7 @@ public sealed partial class Timer
 			public async Task WithoutQuantifier_WhenExecutedAtLeastOnce_ShouldSucceed()
 			{
 				MockTimeSystem timeSystem = new();
-				ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
+				using ITimerMock sut = (ITimerMock)timeSystem.Timer.New(
 					_ => { },
 					null,
 					TimeSpan.Zero,
@@ -134,12 +132,11 @@ public sealed partial class Timer
 
 				async Task Act()
 				{
+					// ReSharper disable once AccessToDisposedClosure
 					await That(sut).Executed().Within(TimeSpan.FromSeconds(30));
 				}
 
 				await That(Act).DoesNotThrow();
-
-				sut.Dispose();
 			}
 		}
 	}

--- a/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/Timer.Executed.Tests.cs
@@ -121,7 +121,11 @@ public sealed class Timer
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*did not execute at least once within 0:00.100*").AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             did not execute at least once within 0:00.100,
+					             but it was executed *
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -143,7 +147,11 @@ public sealed class Timer
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("*did not execute at least 3 times within 0:00.100*").AsWildcard();
+					.WithMessage("""
+					             Expected that sut
+					             did not execute at least 3 times within 0:00.100,
+					             but it was executed *
+					             """).AsWildcard();
 			}
 
 			[Fact]


### PR DESCRIPTION
This pull request introduces a new feature for asserting timer executions in tests using the `ITimerMock` interface. It adds the ability to verify how many times a timer callback has been executed within a specified timeout, making asynchronous timer assertions straightforward and expressive. The changes include the implementation of the core logic, result type, extension methods, documentation, and comprehensive tests.

The most important changes are:

**New Timer Assertion Feature:**

* Added the `TimerExtensions.Executed()` extension method for `ITimerMock`, allowing assertions on timer callback executions with quantifiers and timeouts.
* Implemented the core polling logic in `TimerConstraints.TimerExecutedConstraint`, which checks the execution count until the quantifier is satisfied or the timeout expires.
* Introduced the `TimerExecutedResult` type, providing a fluent API for specifying the timeout window with `.Within(timeout)`.

**Documentation and API Surface:**

* Updated the `README.md` with usage examples for the new timer assertions, explaining how to use quantifiers and timeouts in tests.
* Updated public API files to reflect the new `TimerExtensions` and `TimerExecutedResult` types and methods.

**Testing:**

* Added comprehensive tests in `Timer.Executed.Tests.cs` to verify correct behavior for various timer execution scenarios, including success, failure, live updates, and null subjects.