### PR TITLE
feat: add DoesNotHaveAttribute method for IFileInfo extensions

### DIFF
--- a/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.IO.Abstractions;
 using System.Text;
@@ -15,10 +16,18 @@ public static partial class FileInfoExtensions
 	/// </summary>
 	public static AndOrResult<IFileInfo, IThat<IFileInfo>> HasAttribute(this IThat<IFileInfo> source,
 		FileAttributes expected)
-		=> new(
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected file attributes must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<IFileInfo, IThat<IFileInfo>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, expected)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the <see cref="IFileInfo" /> does not have the <paramref name="unexpected" />
@@ -26,10 +35,18 @@ public static partial class FileInfoExtensions
 	/// </summary>
 	public static AndOrResult<IFileInfo, IThat<IFileInfo>> DoesNotHaveAttribute(this IThat<IFileInfo> source,
 		FileAttributes unexpected)
-		=> new(
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected file attributes must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<IFileInfo, IThat<IFileInfo>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, unexpected).Invert()),
 			source);
+	}
 
 	private sealed class HasAttributeConstraint(string it, ExpectationGrammars grammars, FileAttributes expected)
 		: ConstraintResult.WithValue<IFileInfo>(grammars),

--- a/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
@@ -20,6 +20,17 @@ public static partial class FileInfoExtensions
 				=> new HasAttributeConstraint(it, grammars, expected)),
 			source);
 
+	/// <summary>
+	///     Verifies that the <see cref="IFileInfo" /> does not have the <paramref name="unexpected" />
+	///     <see cref="FileAttributes" />.
+	/// </summary>
+	public static AndOrResult<IFileInfo, IThat<IFileInfo>> DoesNotHaveAttribute(this IThat<IFileInfo> source,
+		FileAttributes unexpected)
+		=> new(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasAttributeConstraint(it, grammars, unexpected).Invert()),
+			source);
+
 	private sealed class HasAttributeConstraint(string it, ExpectationGrammars grammars, FileAttributes expected)
 		: ConstraintResult.WithValue<IFileInfo>(grammars),
 			IValueConstraint<IFileInfo>

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -48,6 +48,7 @@ namespace aweXpect.Testably
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Testably.Results.FileInfoContentResult HasContent(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -43,6 +43,7 @@ namespace aweXpect.Testably
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Testably.Results.FileInfoContentResult HasContent(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -43,6 +43,7 @@ namespace aweXpect.Testably
     public static class FileInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IFileInfo, aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Testably.Results.FileInfoContentResult HasContent(this aweXpect.Core.IThat<System.IO.Abstractions.IFileInfo> source) { }

--- a/Tests/aweXpect.Testably.Tests/FileInfo.DoesNotHaveAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.DoesNotHaveAttribute.Tests.cs
@@ -61,6 +61,23 @@ public sealed partial class FileInfo
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo.txt";
+				fileSystem.File.WriteAllText(path, "");
+				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
+
+				async Task Act()
+				{
+					await That(fileInfo).DoesNotHaveAttribute(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Testably.Tests/FileInfo.DoesNotHaveAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.DoesNotHaveAttribute.Tests.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class FileInfo
+{
+	public sealed class DoesNotHaveAttribute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAttributeIsAbsent_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo.txt";
+				fileSystem.File.WriteAllText(path, "");
+				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
+
+				async Task Act()
+				{
+					await That(fileInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAttributeIsPresent_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo.txt";
+				fileSystem.File.WriteAllText(path, "");
+				fileSystem.File.SetAttributes(path, FileAttributes.ReadOnly);
+				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
+
+				async Task Act()
+				{
+					await That(fileInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that fileInfo
+					             does not have attribute ReadOnly,
+					             but it did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFileDoesNotExist_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				IFileInfo fileInfo = fileSystem.FileInfo.New("foo.txt");
+
+				async Task Act()
+				{
+					await That(fileInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/FileInfo.HasAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/FileInfo.HasAttribute.Tests.cs
@@ -47,6 +47,23 @@ public sealed partial class FileInfo
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo.txt";
+				fileSystem.File.WriteAllText(path, "");
+				IFileInfo fileInfo = fileSystem.FileInfo.New(path);
+
+				async Task Act()
+				{
+					await That(fileInfo).HasAttribute(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds a new negative assertion for `IFileInfo` attribute checks in **aweXpect.Testably**, along with corresponding unit tests and API surface snapshots to ensure the extension is publicly exposed across target frameworks.

**Changes:**
- Introduces `DoesNotHaveAttribute(this IThat<IFileInfo>, FileAttributes unexpected)` on `FileInfoExtensions`.
- Adds unit tests covering success/failure cases (including non-existent file behavior).
- Updates API approval snapshot files for netstandard2.0, net8.0, and net10.0.