### PR TITLE
feat: add `HasAttribute` and `DoesNotHaveAttribute` methods for `IDirectoryInfo` extensions

### DIFF
--- a/Source/aweXpect.Testably/DirectoryInfoExtensions.HasAttribute.cs
+++ b/Source/aweXpect.Testably/DirectoryInfoExtensions.HasAttribute.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+using aweXpect.Testably.Helpers;
+
+namespace aweXpect.Testably;
+
+public static partial class DirectoryInfoExtensions
+{
+	/// <summary>
+	///     Verifies that the <see cref="IDirectoryInfo" /> has the <paramref name="expected" />
+	///     <see cref="FileAttributes" />.
+	/// </summary>
+	public static AndOrResult<IDirectoryInfo, IThat<IDirectoryInfo>> HasAttribute(this IThat<IDirectoryInfo> source,
+		FileAttributes expected)
+	{
+		if (expected == default)
+		{
+			throw new ArgumentException(
+				"The expected file attributes must include at least one flag.", nameof(expected));
+		}
+
+		return new AndOrResult<IDirectoryInfo, IThat<IDirectoryInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileSystemConstraints.HasAttributeConstraint<IDirectoryInfo>(it, grammars, expected)),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="IDirectoryInfo" /> does not have the <paramref name="unexpected" />
+	///     <see cref="FileAttributes" />.
+	/// </summary>
+	public static AndOrResult<IDirectoryInfo, IThat<IDirectoryInfo>> DoesNotHaveAttribute(
+		this IThat<IDirectoryInfo> source,
+		FileAttributes unexpected)
+	{
+		if (unexpected == default)
+		{
+			throw new ArgumentException(
+				"The unexpected file attributes must include at least one flag.", nameof(unexpected));
+		}
+
+		return new AndOrResult<IDirectoryInfo, IThat<IDirectoryInfo>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new FileSystemConstraints.HasAttributeConstraint<IDirectoryInfo>(it, grammars, unexpected).Invert()),
+			source);
+	}
+}

--- a/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
+++ b/Source/aweXpect.Testably/FileInfoExtensions.HasAttribute.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.IO.Abstractions;
-using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Results;
@@ -25,7 +24,7 @@ public static partial class FileInfoExtensions
 
 		return new AndOrResult<IFileInfo, IThat<IFileInfo>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, expected)),
+				=> new FileSystemConstraints.HasAttributeConstraint<IFileInfo>(it, grammars, expected)),
 			source);
 	}
 
@@ -44,58 +43,7 @@ public static partial class FileInfoExtensions
 
 		return new AndOrResult<IFileInfo, IThat<IFileInfo>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, unexpected).Invert()),
+				=> new FileSystemConstraints.HasAttributeConstraint<IFileInfo>(it, grammars, unexpected).Invert()),
 			source);
-	}
-
-	private sealed class HasAttributeConstraint(string it, ExpectationGrammars grammars, FileAttributes expected)
-		: ConstraintResult.WithValue<IFileInfo>(grammars),
-			IValueConstraint<IFileInfo>
-	{
-		private FileAttributes _actualAttributes;
-
-		public ConstraintResult IsMetBy(IFileInfo actual)
-		{
-			Actual = actual;
-			if (!actual.Exists)
-			{
-				Outcome = Outcome.Failure;
-				return this;
-			}
-
-			_actualAttributes = actual.Attributes;
-			Outcome = (_actualAttributes & expected) == expected ? Outcome.Success : Outcome.Failure;
-			return this;
-		}
-
-		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("has attribute ").Append(expected);
-
-		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			if (Actual?.Exists != true)
-			{
-				stringBuilder.Append(it).Append(" did not exist");
-			}
-			else
-			{
-				stringBuilder.Append(it).Append(" was ").Append(_actualAttributes);
-			}
-		}
-
-		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("does not have attribute ").Append(expected);
-
-		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			if (Actual?.Exists != true)
-			{
-				stringBuilder.Append(it).Append(" did not exist");
-			}
-			else
-			{
-				stringBuilder.Append(it).Append(" did");
-			}
-		}
 	}
 }

--- a/Source/aweXpect.Testably/Helpers/FileSystemConstraints.cs
+++ b/Source/aweXpect.Testably/Helpers/FileSystemConstraints.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.IO.Abstractions;
 using System.Text;
 using System.Threading;
@@ -11,6 +12,61 @@ namespace aweXpect.Testably.Helpers;
 
 internal static class FileSystemConstraints
 {
+	internal sealed class HasAttributeConstraint<TInfo>(
+		string it,
+		ExpectationGrammars grammars,
+		FileAttributes expected)
+		: ConstraintResult.WithValue<TInfo>(grammars),
+			IValueConstraint<TInfo>
+		where TInfo : class, IFileSystemInfo
+	{
+		private FileAttributes _actualAttributes;
+
+		public ConstraintResult IsMetBy(TInfo actual)
+		{
+			Actual = actual;
+			if (!actual.Exists)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_actualAttributes = actual.Attributes;
+			Outcome = (_actualAttributes & expected) == expected ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has attribute ").Append(expected);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual?.Exists != true)
+			{
+				stringBuilder.Append(it).Append(" did not exist");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" was ").Append(_actualAttributes);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have attribute ").Append(expected);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual?.Exists != true)
+			{
+				stringBuilder.Append(it).Append(" did not exist");
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
 	internal sealed class ExistsConstraint<TInfo>(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<TInfo>(grammars),
 			IValueConstraint<TInfo>

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net10.0.txt
@@ -28,9 +28,11 @@ namespace aweXpect.Testably
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasCreationTime(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.DateTime expected) { }
         public static aweXpect.Testably.Results.DirectoryResult<System.IO.Abstractions.IDirectoryInfo> HasDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Testably.Results.FileResult<System.IO.Abstractions.IDirectoryInfo> HasFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_net8.0.txt
@@ -28,9 +28,11 @@ namespace aweXpect.Testably
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasCreationTime(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.DateTime expected) { }
         public static aweXpect.Testably.Results.DirectoryResult<System.IO.Abstractions.IDirectoryInfo> HasDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Testably.Results.FileResult<System.IO.Abstractions.IDirectoryInfo> HasFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }

--- a/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
+++ b/Tests/aweXpect.Testably.Api.Tests/Expected/aweXpect.Testably_netstandard2.0.txt
@@ -28,9 +28,11 @@ namespace aweXpect.Testably
     public static class DirectoryInfoExtensions
     {
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotExist(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes unexpected) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> DoesNotHaveFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> Exists(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source) { }
+        public static aweXpect.Results.AndOrResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasAttribute(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.IO.FileAttributes expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.IO.Abstractions.IDirectoryInfo, aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo>> HasCreationTime(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> source, System.DateTime expected) { }
         public static aweXpect.Testably.Results.DirectoryResult<System.IO.Abstractions.IDirectoryInfo> HasDirectory(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }
         public static aweXpect.Testably.Results.FileResult<System.IO.Abstractions.IDirectoryInfo> HasFile(this aweXpect.Core.IThat<System.IO.Abstractions.IDirectoryInfo> subject, string path) { }

--- a/Tests/aweXpect.Testably.Tests/DirectoryInfo.DoesNotHaveAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DirectoryInfo.DoesNotHaveAttribute.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class DirectoryInfo
 
 				async Task Act()
 				{
-					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
 				}
 
 				await That(Act).DoesNotThrow();
@@ -32,18 +32,17 @@ public sealed partial class DirectoryInfo
 				MockFileSystem fileSystem = new();
 				string path = "foo";
 				fileSystem.Directory.CreateDirectory(path);
-				fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
 				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
 
 				async Task Act()
 				{
-					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Directory);
 				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that dirInfo
-					             does not have attribute Hidden,
+					             does not have attribute Directory,
 					             but it did
 					             """);
 			}
@@ -56,7 +55,7 @@ public sealed partial class DirectoryInfo
 
 				async Task Act()
 				{
-					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Directory);
 				}
 
 				await That(Act).DoesNotThrow();

--- a/Tests/aweXpect.Testably.Tests/DirectoryInfo.DoesNotHaveAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DirectoryInfo.DoesNotHaveAttribute.Tests.cs
@@ -1,0 +1,83 @@
+using System.IO;
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DirectoryInfo
+{
+	public sealed class DoesNotHaveAttribute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAttributeIsAbsent_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAttributeIsPresent_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that dirInfo
+					             does not have attribute Hidden,
+					             but it did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenDirectoryDoesNotExist_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New("foo");
+
+				async Task Act()
+				{
+					await That(dirInfo).DoesNotHaveAttribute(FileAttributes.Hidden);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenUnexpectedIsDefault_ShouldThrowArgumentException()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).DoesNotHaveAttribute(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("unexpected");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Testably.Tests/DirectoryInfo.HasAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DirectoryInfo.HasAttribute.Tests.cs
@@ -20,13 +20,13 @@ public sealed partial class DirectoryInfo
 
 				async Task Act()
 				{
-					await That(dirInfo).HasAttribute(FileAttributes.Hidden);
+					await That(dirInfo).HasAttribute(FileAttributes.ReadOnly);
 				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that dirInfo
-					             has attribute Hidden,
+					             has attribute ReadOnly,
 					             but it was Directory
 					             """);
 			}
@@ -37,12 +37,11 @@ public sealed partial class DirectoryInfo
 				MockFileSystem fileSystem = new();
 				string path = "foo";
 				fileSystem.Directory.CreateDirectory(path);
-				fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
 				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
 
 				async Task Act()
 				{
-					await That(dirInfo).HasAttribute(FileAttributes.Hidden);
+					await That(dirInfo).HasAttribute(FileAttributes.Directory);
 				}
 
 				await That(Act).DoesNotThrow();

--- a/Tests/aweXpect.Testably.Tests/DirectoryInfo.HasAttribute.Tests.cs
+++ b/Tests/aweXpect.Testably.Tests/DirectoryInfo.HasAttribute.Tests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
+
+namespace aweXpect.Testably.Tests;
+
+public sealed partial class DirectoryInfo
+{
+	public sealed class HasAttribute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAttributeIsAbsent_ShouldFail()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).HasAttribute(FileAttributes.Hidden);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that dirInfo
+					             has attribute Hidden,
+					             but it was Directory
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAttributeIsPresent_ShouldSucceed()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).HasAttribute(FileAttributes.Hidden);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsDefault_ShouldThrowArgumentException()
+			{
+				MockFileSystem fileSystem = new();
+				string path = "foo";
+				fileSystem.Directory.CreateDirectory(path);
+				IDirectoryInfo dirInfo = fileSystem.DirectoryInfo.New(path);
+
+				async Task Act()
+				{
+					await That(dirInfo).HasAttribute(default);
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithParamName("expected");
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces support for verifying file attributes on directories in the `aweXpect.Testably` library, aligning the API for `IDirectoryInfo` with the existing support for `IFileInfo`. It also refactors attribute constraint logic for better code reuse, and adds comprehensive tests for the new functionality.

New Features:

* Added `HasAttribute` and `DoesNotHaveAttribute` extension methods for `IDirectoryInfo`, allowing assertions on directory attributes in a fluent style.
* Updated the public API documentation to reflect the new methods for `IDirectoryInfo`. 

Refactoring and Code Reuse:

* Moved the attribute constraint logic into a generic `FileSystemConstraints.HasAttributeConstraint<TInfo>` class, now used by both file and directory attribute assertions. This removes duplicate code and ensures consistent behavior.

Testing:

* Added unit tests for the new `HasAttribute` and `DoesNotHaveAttribute` methods on `IDirectoryInfo`, covering both success and failure scenarios as well as argument validation.