### PR TITLE
docs: remove UTF-8 BOM from Docs/pages/00-index.md

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,4 +1,4 @@
-﻿# aweXpect.Testably
+# aweXpect.Testably
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Testably)](https://www.nuget.org/packages/aweXpect.Testably)
 


### PR DESCRIPTION
The BOM preceded the page H1 (`# aweXpect.Testably`), so the docs site rendered it as a literal paragraph instead of a heading. Stripping the BOM lets markdown parse the heading correctly.